### PR TITLE
fix: Include DisplayName in User Resource

### DIFF
--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -24,13 +24,14 @@ resource "pocketid_user" "example" {
 
 # Create a user with full details
 resource "pocketid_user" "full_example" {
-  username   = "jane.smith"
-  email      = "jane.smith@example.com"
-  first_name = "Jane"
-  last_name  = "Smith"
-  locale     = "en-US"
-  is_admin   = false
-  disabled   = false
+  username     = "jane.smith"
+  email        = "jane.smith@example.com"
+  first_name   = "Jane"
+  last_name    = "Smith"
+  display_name = "Jane Smith"  # Optional: if not set, defaults to "first_name last_name"
+  locale       = "en-US"
+  is_admin     = false
+  disabled     = false
 }
 
 # Create an admin user
@@ -97,6 +98,7 @@ resource "pocketid_user" "team" {
 ### Optional
 
 - `disabled` (Boolean) Whether the user account is disabled. Defaults to false. Note: Due to API limitations, this field cannot be set during user creation. To create a disabled user, first create the user and then update it to set disabled to true.
+- `display_name` (String) The display name of the user. If not provided, it is automatically set to first_name + last_name.
 - `first_name` (String) The first name of the user.
 - `groups` (Set of String) List of group IDs the user belongs to.
 - `is_admin` (Boolean) Whether the user has administrator privileges. Defaults to false.

--- a/examples/user-management/main.tf
+++ b/examples/user-management/main.tf
@@ -70,6 +70,26 @@ resource "pocketid_user" "support_user" {
   groups     = [pocketid_group.support.id]
 }
 
+# Create a user with a custom display name
+resource "pocketid_user" "custom_display_name" {
+  username     = "jsmith"
+  email        = "j.smith@example.com"
+  first_name   = "John"
+  last_name    = "Smith"
+  display_name = "JS"  # Custom display name instead of "John Smith"
+  groups       = [pocketid_group.developers.id]
+}
+
+# Create a user where display_name is auto-generated from first and last names
+resource "pocketid_user" "auto_display_name" {
+  username   = "jdoe"
+  email      = "jane.doe@example.com"
+  first_name = "Jane"
+  last_name  = "Doe"
+  # display_name will automatically be set to "Jane Doe" by the API
+  groups = [pocketid_group.support.id]
+}
+
 # Example of a disabled user
 resource "pocketid_user" "disabled_user" {
   username   = "former.employee"

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -75,6 +75,7 @@ type User struct {
 	Email        string        `json:"email"`
 	FirstName    string        `json:"firstName,omitempty"`
 	LastName     string        `json:"lastName,omitempty"`
+	DisplayName  string        `json:"displayName,omitempty"`
 	IsAdmin      bool          `json:"isAdmin"`
 	Locale       *string       `json:"locale,omitempty"`
 	Disabled     bool          `json:"disabled"`
@@ -87,13 +88,14 @@ type User struct {
 
 // UserCreateRequest represents a request to create or update a user
 type UserCreateRequest struct {
-	Username  string  `json:"username"`
-	Email     string  `json:"email"`
-	FirstName string  `json:"firstName,omitempty"`
-	LastName  string  `json:"lastName,omitempty"`
-	IsAdmin   bool    `json:"isAdmin"`
-	Locale    *string `json:"locale,omitempty"`
-	Disabled  bool    `json:"disabled"`
+	Username    string  `json:"username"`
+	Email       string  `json:"email"`
+	FirstName   string  `json:"firstName,omitempty"`
+	LastName    string  `json:"lastName,omitempty"`
+	DisplayName string  `json:"displayName,omitempty"`
+	IsAdmin     bool    `json:"isAdmin"`
+	Locale      *string `json:"locale,omitempty"`
+	Disabled    bool    `json:"disabled"`
 }
 
 // UpdateUserGroupsRequest represents a request to update a user's groups

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -49,6 +49,27 @@ func TestAccResourceUser_basic(t *testing.T) {
 	})
 }
 
+func TestAccResourceUser_displayNameDefault(t *testing.T) {
+	resourceName := "pocketid_user.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Create user without display_name - should default to "Test User"
+			{
+				Config: testAccResourceUserConfig_displayNameDefault("test-display-name", "testdisplayname@example.com"),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", "test-display-name"),
+					resource.TestCheckResourceAttr(resourceName, "first_name", "Test"),
+					resource.TestCheckResourceAttr(resourceName, "last_name", "User"),
+					resource.TestCheckResourceAttr(resourceName, "display_name", "Test User"),
+				),
+			},
+		},
+	})
+}
+
 func TestAccResourceUser_withGroups(t *testing.T) {
 	resourceName := "pocketid_user.test"
 
@@ -151,6 +172,17 @@ func testAccCheckUserGroupsSet(resourceName string) resource.TestCheckFunc {
 }
 
 func testAccResourceUserConfig_basic(username, email string) string {
+	return fmt.Sprintf(`
+resource "pocketid_user" "test" {
+  username   = %[1]q
+  email      = %[2]q
+  first_name = "Test"
+  last_name  = "User"
+}
+`, username, email)
+}
+
+func testAccResourceUserConfig_displayNameDefault(username, email string) string {
 	return fmt.Sprintf(`
 resource "pocketid_user" "test" {
   username   = %[1]q


### PR DESCRIPTION
Resolves #30

This pull request adds support for the required `displayName` field introduced in PocketID [v1.11.0](https://github.com/pocket-id/pocket-id/releases/tag/v1.11.0) as a required field. The Terraform provider now handles the `displayName` field in user creation and updates, with automatic defaulting from first and last names when not explicitly provided.

### Bug Fix: DisplayName Field Support

* Added `displayName` field to the Terraform resource schema (`userResourceModel`) and the API request model (`UserCreateRequest`), allowing users to optionally specify a custom display name for users.
* Implemented automatic display name generation: when not explicitly set, `displayName` defaults to "FirstName LastName" (or just the first or last name if only one is provided).
* Updated the resource creation and update logic to include the display name in API requests, with intelligent defaulting based on first and last names.
* Fixed the Update method to properly populate all state values from the API response, including the newly supported `displayName` field.
* Updated the Read method to populate `displayName` from API responses.

### Documentation Updates

* Added documentation for the `display_name` field in `docs/resources/user.md` with clear explanation of automatic defaulting  behavior.
* Added comprehensive examples showing both custom and auto-generated display names in `examples/resources/users_groups.tf`:
  - Example: User with custom display name ("JS" for John Smith)
  - Example: User with auto-generated display name ("Jane Doe")
* Updated the user-management example in `examples/user-management/main.tf` with practical display name usage patterns.

### Testing

* Added acceptance test `TestAccResourceUser_displayNameDefault()` to validate the automatic display name generation from first and last names.
* All existing unit tests continue to pass.

### Compatibility

* This change is fully backward compatible - existing Terraform configurations without `display_name` will automatically generate it from first and last names.
* Resolves compatibility issues with PocketID v1.11.0+ where `displayName` became a required field.