### PR TITLE
ci: bump Go to 1.25 for terraform-plugin updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
       - develop
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
   GOLANGCI_LINT_VERSION: "v2.2.1"
 
 permissions:
@@ -97,7 +97,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Download dependencies

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,7 +6,7 @@ on:
       - main
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25"
 
 permissions:
   contents: write

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
         with:
-          go-version: "1.24"
+          go-version: "1.25"
           cache: true
 
       - name: Run gosec security scanner


### PR DESCRIPTION
## Summary
Bumps `GO_VERSION` from 1.24 to 1.25 across the CI, security, and pre-release workflows.

## Why
The updated HashiCorp terraform-plugin libraries require a newer Go toolchain:
- `terraform-plugin-testing` 1.16 requires Go >= 1.25.8
- `terraform-plugin-framework` 1.19 and `terraform-plugin-go` 0.31 require Go >= 1.25.0

With `GOTOOLCHAIN=local` the CI was pinned to Go 1.24 and failed `go.mod requires go >= 1.25.8`. This unblocks the pending dependency-update PRs (#61 and the superseded #53/#54/#55).

## Scope
Workflow-only change (no Go files), so the Go build/test jobs are skipped here; the bump is exercised by the rebased dependency PRs.