### PR TITLE
ci: bump golangci-lint to v2.12.2 for Go 1.25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ on:
 
 env:
   GO_VERSION: "1.25"
-  GOLANGCI_LINT_VERSION: "v2.2.1"
+  GOLANGCI_LINT_VERSION: "v2.12.2"
 
 permissions:
   contents: read


### PR DESCRIPTION
Follow-up to #64. golangci-lint v2.2.1 is built with Go 1.24 and errors when the project targets Go 1.25.8. v2.12.2 (built with Go 1.26) lints the codebase cleanly. Verified locally against the pending go-minor update (#61): 0 issues.