### PR TITLE
fix: v2 API correctness (client_id, user disabled, one-time-access-token ttl)

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -148,7 +148,7 @@ output "spa_client_id" {
 ### Optional
 
 - `allowed_user_groups` (List of String) List of user group IDs that are allowed to use this client. If empty, all users can use this client.
-- `client_id` (String) The client ID to use for the OIDC client. If not set, one will be generated.
+- `client_id` (String) The client ID to use for the OIDC client. If not set, one will be generated. Must be between 2 and 128 characters.
 - `is_public` (Boolean) Whether this is a public client (no client secret). Defaults to false.
 - `launch_url` (String) Optional launch URL associated with the client.
 - `logout_callback_urls` (List of String) List of allowed logout callback URLs for the OIDC client.

--- a/docs/resources/one_time_access_token.md
+++ b/docs/resources/one_time_access_token.md
@@ -3,26 +3,20 @@
 page_title: "pocketid_one_time_access_token Resource - terraform-provider-pocketid"
 subcategory: ""
 description: |-
-  Manages a one-time access token for a user in Pocket-ID. These tokens allow users to authenticate when they don't have access to their passkey.
+  Manages a one-time access token for a user in Pocket-ID. These tokens let a user authenticate when they don't have access to their passkey. The token value is returned only once on creation and cannot be read back (pocket-id exposes no read endpoint), so it is stored in Terraform state as a sensitive value.
 ---
 
 # pocketid_one_time_access_token (Resource)
 
-Manages a one-time access token for a user in Pocket-ID. These tokens allow users to authenticate when they don't have access to their passkey.
+Manages a one-time access token for a user in Pocket-ID. These tokens let a user authenticate when they don't have access to their passkey. The token value is returned only once on creation and cannot be read back (pocket-id exposes no read endpoint), so it is stored in Terraform state as a sensitive value.
 
 ## Example Usage
 
 ```terraform
-# Create a one-time access token for a user (expires_at is required)
+# Create a one-time access token for a user, valid for 1 hour
 resource "pocketid_one_time_access_token" "example" {
-  user_id    = pocketid_user.example.id
-  expires_at = timeadd(timestamp(), "24h") # Token expires in 24 hours
-}
-
-# Create a one-time access token with custom expiry (1 hour from now)
-resource "pocketid_one_time_access_token" "temporary" {
-  user_id    = pocketid_user.example.id
-  expires_at = timeadd(timestamp(), "1h")
+  user_id = pocketid_user.example.id
+  ttl     = "1h"
 }
 
 # Example with user creation
@@ -40,7 +34,7 @@ output "access_token" {
   sensitive   = true
 }
 
-# Use case: Create a token for emergency access
+# Use case: Create a token for emergency access, valid for 24 hours
 resource "pocketid_user" "emergency" {
   username   = "emergency.access"
   email      = "emergency@example.com"
@@ -50,16 +44,16 @@ resource "pocketid_user" "emergency" {
 }
 
 resource "pocketid_one_time_access_token" "emergency" {
-  user_id    = pocketid_user.emergency.id
-  expires_at = timeadd(timestamp(), "24h") # Valid for 24 hours
+  user_id = pocketid_user.emergency.id
+  ttl     = "24h"
 }
 
 # Note: One-time access tokens are useful when users need to authenticate
 # from a device where they don't have access to their passkey.
-# The token can only be used once and should be treated as a secret.
+# The token can only be used once and should be treated as a secret. Its value
+# is returned only on creation and cannot be read back from the API.
 
-# Use case: Initial user setup with skip_recreate
-# This prevents Terraform from recreating the token after it's been used
+# Use case: Initial user setup, token valid for 7 days
 resource "pocketid_user" "new_user" {
   username   = "new.employee"
   email      = "new.employee@company.com"
@@ -68,9 +62,8 @@ resource "pocketid_user" "new_user" {
 }
 
 resource "pocketid_one_time_access_token" "onboarding" {
-  user_id       = pocketid_user.new_user.id
-  expires_at    = timeadd(timestamp(), "168h") # Valid for 7 days
-  skip_recreate = true                         # Don't recreate if token is used
+  user_id = pocketid_user.new_user.id
+  ttl     = "168h" # 7 days (max ttl is 744h / 31 days)
 }
 
 # Send the token via another provider (e.g., email, SMS)
@@ -94,18 +87,15 @@ resource "example_email" "welcome" {
 
 ### Required
 
-- `expires_at` (String) The expiration time of the token in RFC3339 format
-- `user_id` (String) The ID of the user this token belongs to
-
-### Optional
-
-- `skip_recreate` (Boolean) If true (default), the resource will not be recreated when the token is not found (used or expired). This is useful for initial user setup where the token is sent via another provider. Note: Setting this to false will enable standard Terraform behavior, where the resource is recreated if the token is missing.
+- `ttl` (String) Lifetime of the token expressed as a Go duration string (e.g. `15m`, `1h`, `24h`). Must be greater than 1 second and at most 744h (31 days). Changing this forces a new token to be created.
+- `user_id` (String) The ID of the user this token belongs to.
 
 ### Read-Only
 
-- `created_at` (String) The creation time of the token in RFC3339 format
-- `id` (String) The unique identifier of the one-time access token (same as user_id)
-- `token` (String, Sensitive) The one-time access token value
+- `created_at` (String) The creation time of the token in RFC3339 format.
+- `expires_at` (String) The computed expiration time of the token in RFC3339 format (created_at + ttl).
+- `id` (String) The unique identifier of the one-time access token (same as user_id).
+- `token` (String, Sensitive) The one-time access token value. Returned only on creation.
 
 ## Import
 

--- a/docs/resources/user.md
+++ b/docs/resources/user.md
@@ -96,7 +96,7 @@ resource "pocketid_user" "team" {
 
 ### Optional
 
-- `disabled` (Boolean) Whether the user account is disabled. Defaults to false. Note: Due to API limitations, this field cannot be set during user creation. To create a disabled user, first create the user and then update it to set disabled to true.
+- `disabled` (Boolean) Whether the user account is disabled. Defaults to false.
 - `display_name` (String) The display name of the user. Computed from first and last name if not set.
 - `first_name` (String) The first name of the user.
 - `groups` (Set of String) List of group IDs the user belongs to.

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -238,20 +238,16 @@ resource "pocketid_user" "test_users" {
   groups = [pocketid_group.users.id]
 }
 
-# Note: one_time_access_token resource is not available in v0.1.5
-# Uncomment when using a newer version that supports this resource
-#
-# # Create one-time access tokens for initial user setup
+# Create one-time access tokens for initial user setup.
+# The token value is returned only on creation and cannot be read back.
 # resource "pocketid_one_time_access_token" "admin_token" {
-#   user_id       = pocketid_user.admin_user.id
-#   expires_at    = timeadd(timestamp(), "24h")
-#   skip_recreate = true
+#   user_id = pocketid_user.admin_user.id
+#   ttl     = "24h"
 # }
 #
 # resource "pocketid_one_time_access_token" "dev_onboarding" {
-#   user_id       = pocketid_user.developer.id
-#   expires_at    = timeadd(timestamp(), "168h") # 7 days
-#   skip_recreate = true
+#   user_id = pocketid_user.developer.id
+#   ttl     = "168h" # 7 days
 # }
 #
 # output "admin_token_value" {

--- a/examples/resources/pocketid_one_time_access_token/import.tf
+++ b/examples/resources/pocketid_one_time_access_token/import.tf
@@ -12,9 +12,7 @@ import {
 
 # The resource block that the import will populate:
 resource "pocketid_one_time_access_token" "example" {
-  # These values will be populated from the import
-  # except for the token which cannot be retrieved
-  user_id       = "user-id-123"
-  expires_at    = "2024-12-31T23:59:59Z"
-  skip_recreate = true
+  # user_id is populated from the import; the token value cannot be retrieved.
+  user_id = "user-id-123"
+  ttl     = "1h"
 }

--- a/examples/resources/pocketid_one_time_access_token/resource.tf
+++ b/examples/resources/pocketid_one_time_access_token/resource.tf
@@ -1,13 +1,7 @@
-# Create a one-time access token for a user
+# Create a one-time access token for a user, valid for 1 hour
 resource "pocketid_one_time_access_token" "example" {
-  user_id    = pocketid_user.example.id
-  expires_at = timeadd(timestamp(), "1h") # Valid for 1 hour
-}
-
-# Create a one-time access token with custom expiry (1 hour from now)
-resource "pocketid_one_time_access_token" "temporary" {
-  user_id    = pocketid_user.example.id
-  expires_at = timeadd(timestamp(), "1h")
+  user_id = pocketid_user.example.id
+  ttl     = "1h"
 }
 
 # Example with user creation
@@ -25,7 +19,7 @@ output "access_token" {
   sensitive   = true
 }
 
-# Use case: Create a token for emergency access
+# Use case: Create a token for emergency access, valid for 24 hours
 resource "pocketid_user" "emergency" {
   username   = "emergency.access"
   email      = "emergency@example.com"
@@ -35,16 +29,16 @@ resource "pocketid_user" "emergency" {
 }
 
 resource "pocketid_one_time_access_token" "emergency" {
-  user_id    = pocketid_user.emergency.id
-  expires_at = timeadd(timestamp(), "24h") # Valid for 24 hours
+  user_id = pocketid_user.emergency.id
+  ttl     = "24h"
 }
 
 # Note: One-time access tokens are useful when users need to authenticate
 # from a device where they don't have access to their passkey.
-# The token can only be used once and should be treated as a secret.
+# The token can only be used once and should be treated as a secret. Its value
+# is returned only on creation and cannot be read back from the API.
 
-# Use case: Initial user setup with skip_recreate
-# This prevents Terraform from recreating the token after it's been used
+# Use case: Initial user setup, token valid for 7 days
 resource "pocketid_user" "new_user" {
   username   = "new.employee"
   email      = "new.employee@company.com"
@@ -53,9 +47,8 @@ resource "pocketid_user" "new_user" {
 }
 
 resource "pocketid_one_time_access_token" "onboarding" {
-  user_id       = pocketid_user.new_user.id
-  expires_at    = timeadd(timestamp(), "168h") # Valid for 7 days
-  skip_recreate = true                         # Don't recreate if token is used
+  user_id = pocketid_user.new_user.id
+  ttl     = "168h" # 7 days (max ttl is 744h / 31 days)
 }
 
 # Send the token via another provider (e.g., email, SMS)

--- a/internal/client/client.go
+++ b/internal/client/client.go
@@ -536,54 +536,25 @@ func (c *Client) ListUserGroups() (*PaginatedResponse[UserGroup], error) {
 	return &result, nil
 }
 
-// OneTimeAccessToken represents a one-time access token
+// OneTimeAccessToken represents a one-time access token. The create endpoint
+// only returns the token value; pocket-id v2 exposes no GET endpoint.
 type OneTimeAccessToken struct {
-	Token     string    `json:"token"`
-	UserID    string    `json:"user_id"`
-	ExpiresAt time.Time `json:"expires_at"`
-	CreatedAt time.Time `json:"created_at"`
+	Token string `json:"token"`
 }
 
-// OneTimeAccessTokenRequest represents a request to create a one-time access token
+// OneTimeAccessTokenRequest represents a request to create a one-time access token.
+// The API expects a ttl (lifetime) as a duration string, e.g. "15m" or "1h".
 type OneTimeAccessTokenRequest struct {
-	ExpiresAt *time.Time `json:"ExpiresAt"`
-}
-
-// GetOneTimeAccessToken checks if a one-time access token exists for a user
-func (c *Client) GetOneTimeAccessToken(userID string) (*OneTimeAccessToken, error) {
-	_, err := c.doRequest("GET", fmt.Sprintf("/api/users/%s/one-time-access-token", userID), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// The GET endpoint only confirms existence, doesn't return token details
-	// Return an empty token object to indicate it exists
-	return &OneTimeAccessToken{}, nil
+	TTL string `json:"ttl"`
 }
 
 // CreateOneTimeAccessToken creates a new one-time access token for a user
 func (c *Client) CreateOneTimeAccessToken(userID string, req *OneTimeAccessTokenRequest) (*OneTimeAccessToken, error) {
-	// Debug log the request
 	ctx := context.Background()
-	if req != nil && req.ExpiresAt != nil {
-		tflog.Debug(ctx, "CreateOneTimeAccessToken request", map[string]interface{}{
-			"user_id":    userID,
-			"expires_at": req.ExpiresAt.Format(time.RFC3339),
-		})
-	} else {
-		tflog.Debug(ctx, "CreateOneTimeAccessToken request with nil expires_at", map[string]interface{}{
-			"user_id":    userID,
-			"req_is_nil": req == nil,
-		})
-	}
-
-	// Also log the JSON that will be sent
-	if req != nil {
-		jsonData, _ := json.Marshal(req)
-		tflog.Debug(ctx, "CreateOneTimeAccessToken JSON", map[string]interface{}{
-			"json": string(jsonData),
-		})
-	}
+	tflog.Debug(ctx, "CreateOneTimeAccessToken request", map[string]interface{}{
+		"user_id": userID,
+		"ttl":     req.TTL,
+	})
 
 	body, err := c.doRequestWithContext(ctx, "POST", fmt.Sprintf("/api/users/%s/one-time-access-token", userID), req)
 	if err != nil {
@@ -596,10 +567,4 @@ func (c *Client) CreateOneTimeAccessToken(userID string, req *OneTimeAccessToken
 	}
 
 	return &token, nil
-}
-
-// DeleteOneTimeAccessToken deletes the one-time access token for a user
-func (c *Client) DeleteOneTimeAccessToken(userID string) error {
-	_, err := c.doRequest("DELETE", fmt.Sprintf("/api/users/%s/one-time-access-token", userID), nil)
-	return err
 }

--- a/internal/client/client_test.go
+++ b/internal/client/client_test.go
@@ -654,64 +654,41 @@ func TestClient_CreateOneTimeAccessToken(t *testing.T) {
 	c, err := client.NewClient(server.URL, "test-token", false, 30)
 	require.NoError(t, err)
 
-	// Test without expiry
-	token, err := c.CreateOneTimeAccessToken("test-user-id", &client.OneTimeAccessTokenRequest{})
+	token, err := c.CreateOneTimeAccessToken("test-user-id", &client.OneTimeAccessTokenRequest{TTL: "15m"})
 	assert.NoError(t, err)
 	assert.Equal(t, "test-token-123456", token.Token)
-	// API doesn't return UserID, ExpiresAt, or CreatedAt
-
-	// Test with expiry
-	expiresAt := time.Now().Add(2 * time.Hour)
-	tokenWithExpiry, err := c.CreateOneTimeAccessToken("test-user-id", &client.OneTimeAccessTokenRequest{
-		ExpiresAt: &expiresAt,
-	})
-	assert.NoError(t, err)
-	assert.Equal(t, "test-token-123456", tokenWithExpiry.Token)
 }
 
-func TestClient_GetOneTimeAccessToken(t *testing.T) {
+func TestClient_CreateOneTimeAccessToken_SendsTTL(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "GET", r.Method)
-		assert.Equal(t, "/api/users/test-user-id/one-time-access-token", r.URL.Path)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		// The provider must send the lifetime as a "ttl" duration string.
+		assert.Equal(t, "1h", body["ttl"])
+		_, hasExpiresAt := body["expiresAt"]
+		assert.False(t, hasExpiresAt, "request must not send expiresAt")
 
-		// The API returns empty response for GET, just confirming existence
-		w.WriteHeader(http.StatusOK)
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]string{"token": "tok"}); err != nil {
+			t.Fatalf("Failed to encode response: %v", err)
+		}
 	}))
 	defer server.Close()
 
 	c, err := client.NewClient(server.URL, "test-token", false, 30)
 	require.NoError(t, err)
 
-	token, err := c.GetOneTimeAccessToken("test-user-id")
+	token, err := c.CreateOneTimeAccessToken("test-user-id", &client.OneTimeAccessTokenRequest{TTL: "1h"})
 	assert.NoError(t, err)
-	assert.NotNil(t, token)
-	// The GET endpoint only confirms existence, doesn't return token details
-	assert.Empty(t, token.Token)
-	assert.Empty(t, token.UserID)
+	assert.Equal(t, "tok", token.Token)
 }
 
-func TestClient_DeleteOneTimeAccessToken(t *testing.T) {
-	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		assert.Equal(t, "DELETE", r.Method)
-		assert.Equal(t, "/api/users/test-user-id/one-time-access-token", r.URL.Path)
-
-		w.WriteHeader(http.StatusNoContent)
-	}))
-	defer server.Close()
-
-	c, err := client.NewClient(server.URL, "test-token", false, 30)
-	require.NoError(t, err)
-
-	err = c.DeleteOneTimeAccessToken("test-user-id")
-	assert.NoError(t, err)
-}
-
-func TestClient_OneTimeAccessToken_Error(t *testing.T) {
+func TestClient_CreateOneTimeAccessToken_Error(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
+		w.WriteHeader(http.StatusBadRequest)
 		if err := json.NewEncoder(w).Encode(&client.ErrorResponse{
-			Error: "One-time access token not found",
+			Error: "invalid ttl",
 		}); err != nil {
 			t.Fatalf("Failed to encode response: %v", err)
 		}
@@ -721,14 +698,7 @@ func TestClient_OneTimeAccessToken_Error(t *testing.T) {
 	c, err := client.NewClient(server.URL, "test-token", false, 30)
 	require.NoError(t, err)
 
-	// Test GET error
-	_, err = c.GetOneTimeAccessToken("test-user-id")
+	_, err = c.CreateOneTimeAccessToken("test-user-id", &client.OneTimeAccessTokenRequest{TTL: "1s"})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "404")
-	assert.Contains(t, err.Error(), "One-time access token not found")
-
-	// Test DELETE error
-	err = c.DeleteOneTimeAccessToken("test-user-id")
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "404")
+	assert.Contains(t, err.Error(), "invalid ttl")
 }

--- a/internal/provider/resource_one_time_access_token_test.go
+++ b/internal/provider/resource_one_time_access_token_test.go
@@ -6,7 +6,6 @@ package provider_test
 import (
 	"fmt"
 	"regexp"
-	"strings"
 	"testing"
 	"time"
 
@@ -24,56 +23,38 @@ func TestAccResourceOneTimeAccessToken_basic(t *testing.T) {
 		Steps: []resource.TestStep{
 			// Create and Read testing
 			{
-				Config: testAccResourceOneTimeAccessTokenConfig_basic(),
+				Config: testAccResourceOneTimeAccessTokenConfig_basic("1h"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrPair(resourceName, "user_id", userResourceName, "id"),
 					resource.TestCheckResourceAttrPair(resourceName, "id", userResourceName, "id"),
+					resource.TestCheckResourceAttr(resourceName, "ttl", "1h"),
 					resource.TestCheckResourceAttrSet(resourceName, "token"),
 					resource.TestCheckResourceAttrSet(resourceName, "expires_at"),
 					resource.TestCheckResourceAttrSet(resourceName, "created_at"),
 					testAccCheckOneTimeAccessTokenValid(resourceName),
+					testAccCheckOneTimeAccessTokenExpiryInFuture(resourceName),
 				),
 			},
-			// Import testing
+			// Import testing. The token value and computed timestamps cannot be
+			// recovered from the API, and ttl is config-only, so they are ignored.
 			{
 				ResourceName:            resourceName,
 				ImportState:             true,
 				ImportStateVerify:       true,
-				ImportStateVerifyIgnore: []string{"token", "expires_at", "created_at"}, // These values can't be retrieved from API
+				ImportStateVerifyIgnore: []string{"token", "ttl", "expires_at", "created_at"},
 			},
 		},
 	})
 }
 
-func TestAccResourceOneTimeAccessToken_withExpiry(t *testing.T) {
-	resourceName := "pocketid_one_time_access_token.test"
-	// Set expiry to 1 hour from now
-	expiresAt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
-
+func TestAccResourceOneTimeAccessToken_invalidTTL(t *testing.T) {
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
 			{
-				Config: testAccResourceOneTimeAccessTokenConfig_withExpiry(expiresAt),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttrSet(resourceName, "token"),
-					resource.TestCheckResourceAttr(resourceName, "expires_at", expiresAt),
-					testAccCheckOneTimeAccessTokenExpiry(resourceName, expiresAt),
-				),
-			},
-		},
-	})
-}
-
-func TestAccResourceOneTimeAccessToken_invalidExpiry(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			{
-				Config:      testAccResourceOneTimeAccessTokenConfig_withExpiry("invalid-date"),
-				ExpectError: regexp.MustCompile("Invalid expires_at format"),
+				Config:      testAccResourceOneTimeAccessTokenConfig_basic("not-a-duration"),
+				ExpectError: regexp.MustCompile("Invalid ttl"),
 			},
 		},
 	})
@@ -105,23 +86,20 @@ func TestAccResourceOneTimeAccessToken_recreateOnUserChange(t *testing.T) {
 }
 
 func TestAccResourceOneTimeAccessToken_deleteUser(t *testing.T) {
-	// Test that the token is removed from state when the user is deleted
+	// Removing the token (and its user) from config destroys it cleanly.
 	resource.Test(t, resource.TestCase{
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create token
 			{
-				Config: testAccResourceOneTimeAccessTokenConfig_basic(),
+				Config: testAccResourceOneTimeAccessTokenConfig_basic("1h"),
 				Check: resource.ComposeAggregateTestCheckFunc(
 					resource.TestCheckResourceAttrSet("pocketid_one_time_access_token.test", "token"),
 				),
 			},
-			// Delete user (token should be removed from state on next read)
 			{
 				Config: testAccResourceOneTimeAccessTokenConfig_noUser(),
 				Check: resource.ComposeAggregateTestCheckFunc(
-					// The token resource should be gone
 					testAccCheckResourceNotExists("pocketid_one_time_access_token.test"),
 				),
 			},
@@ -138,8 +116,7 @@ func testAccCheckOneTimeAccessTokenValid(resourceName string) resource.TestCheck
 			return fmt.Errorf("resource not found: %s", resourceName)
 		}
 
-		token := rs.Primary.Attributes["token"]
-		if token == "" {
+		if rs.Primary.Attributes["token"] == "" {
 			return fmt.Errorf("token is empty")
 		}
 
@@ -147,7 +124,7 @@ func testAccCheckOneTimeAccessTokenValid(resourceName string) resource.TestCheck
 	}
 }
 
-func testAccCheckOneTimeAccessTokenExpiry(resourceName, expectedExpiry string) resource.TestCheckFunc {
+func testAccCheckOneTimeAccessTokenExpiryInFuture(resourceName string) resource.TestCheckFunc {
 	return func(s *terraform.State) error {
 		rs, ok := s.RootModule().Resources[resourceName]
 		if !ok {
@@ -155,21 +132,13 @@ func testAccCheckOneTimeAccessTokenExpiry(resourceName, expectedExpiry string) r
 		}
 
 		expiresAt := rs.Primary.Attributes["expires_at"]
-		if expiresAt != expectedExpiry {
-			return fmt.Errorf("expires_at mismatch: got %s, expected %s", expiresAt, expectedExpiry)
-		}
-
-		// Parse and validate the expiry time
 		expiryTime, err := time.Parse(time.RFC3339, expiresAt)
 		if err != nil {
 			return fmt.Errorf("invalid expires_at format: %s", err)
 		}
-
-		// Check that expiry is in the future
 		if expiryTime.Before(time.Now()) {
 			return fmt.Errorf("token already expired: %s", expiresAt)
 		}
-
 		return nil
 	}
 }
@@ -186,8 +155,7 @@ func testAccCheckResourceNotExists(resourceName string) resource.TestCheckFunc {
 
 // Configuration functions
 
-func testAccResourceOneTimeAccessTokenConfig_basic() string {
-	expiresAt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
+func testAccResourceOneTimeAccessTokenConfig_basic(ttl string) string {
 	return fmt.Sprintf(`
 resource "pocketid_user" "test" {
   username   = "token-test-user"
@@ -197,30 +165,13 @@ resource "pocketid_user" "test" {
 }
 
 resource "pocketid_one_time_access_token" "test" {
-  user_id    = pocketid_user.test.id
-  expires_at = "%s"
+  user_id = pocketid_user.test.id
+  ttl     = %q
 }
-`, expiresAt)
-}
-
-func testAccResourceOneTimeAccessTokenConfig_withExpiry(expiresAt string) string {
-	return fmt.Sprintf(`
-resource "pocketid_user" "test" {
-  username   = "token-test-user"
-  email      = "token-test@example.com"
-  first_name = "Token"
-  last_name  = "Test"
-}
-
-resource "pocketid_one_time_access_token" "test" {
-  user_id    = pocketid_user.test.id
-  expires_at = %q
-}
-`, expiresAt)
+`, ttl)
 }
 
 func testAccResourceOneTimeAccessTokenConfig_twoUsers(activeUser string) string {
-	expiresAt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
 	return fmt.Sprintf(`
 resource "pocketid_user" "user1" {
   username   = "token-test-user1"
@@ -237,76 +188,14 @@ resource "pocketid_user" "user2" {
 }
 
 resource "pocketid_one_time_access_token" "test" {
-  user_id    = pocketid_user.%s.id
-  expires_at = "%s"
+  user_id = pocketid_user.%s.id
+  ttl     = "1h"
 }
-`, activeUser, expiresAt)
+`, activeUser)
 }
 
 func testAccResourceOneTimeAccessTokenConfig_noUser() string {
 	return `
 # User deleted, token should be removed from state
 `
-}
-
-func TestAccOneTimeAccessTokenResource_SkipRecreate(t *testing.T) {
-	resource.Test(t, resource.TestCase{
-		PreCheck:                 func() { testAccPreCheck(t) },
-		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
-		Steps: []resource.TestStep{
-			// Create with skip_recreate = true
-			{
-				Config: testAccOneTimeAccessTokenResourceConfig_skipRecreate("skip.recreate.user", true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("pocketid_one_time_access_token.test", "skip_recreate", "true"),
-					resource.TestCheckResourceAttrSet("pocketid_one_time_access_token.test", "token"),
-					resource.TestCheckResourceAttrSet("pocketid_one_time_access_token.test", "created_at"),
-				),
-			},
-			// Test that resource persists even when token is not found
-			{
-				PreConfig: func() {
-					// This simulates the token being used/deleted outside of Terraform
-					// Note: In real usage, we can't actually delete the token since
-					// the API might not allow it or the token might be auto-deleted after use
-				},
-				Config: testAccOneTimeAccessTokenResourceConfig_skipRecreate("skip.recreate.user", true),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					// The resource should still exist in state
-					resource.TestCheckResourceAttr("pocketid_one_time_access_token.test", "skip_recreate", "true"),
-				),
-			},
-			// Test with skip_recreate = false (default behavior)
-			{
-				Config: testAccOneTimeAccessTokenResourceConfig_skipRecreate("normal.user", false),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr("pocketid_one_time_access_token.test2", "skip_recreate", "false"),
-					resource.TestCheckResourceAttrSet("pocketid_one_time_access_token.test2", "token"),
-				),
-			},
-		},
-	})
-}
-
-func testAccOneTimeAccessTokenResourceConfig_skipRecreate(username string, skipRecreate bool) string {
-	resourceName := "test"
-	if !skipRecreate {
-		resourceName = "test2"
-	}
-	expiresAt := time.Now().Add(1 * time.Hour).UTC().Format(time.RFC3339)
-
-	return fmt.Sprintf(`
-resource "pocketid_user" "%[1]s" {
-  username   = "%[1]s"
-  email      = "%[1]s@example.com"
-  first_name = "Test"
-  last_name  = "User"
-}
-
-resource "pocketid_one_time_access_token" "%[2]s" {
-  user_id       = pocketid_user.%[1]s.id
-  expires_at    = "%[4]s"
-  skip_recreate = %[3]t
-}
-`, strings.ReplaceAll(username, ".", "_"), resourceName, skipRecreate, expiresAt)
 }

--- a/internal/provider/resource_user_test.go
+++ b/internal/provider/resource_user_test.go
@@ -117,18 +117,11 @@ func TestAccResourceUser_disabled(t *testing.T) {
 		PreCheck:                 func() { testAccPreCheck(t) },
 		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
 		Steps: []resource.TestStep{
-			// Create user (API limitation: cannot create as disabled)
-			{
-				Config: testAccResourceUserConfig_basic("disabled-user", "disabled@example.com"),
-				Check: resource.ComposeAggregateTestCheckFunc(
-					resource.TestCheckResourceAttr(resourceName, "username", "disabled-user"),
-					resource.TestCheckResourceAttr(resourceName, "disabled", "false"),
-				),
-			},
-			// Update to disable user
+			// Create user directly as disabled (supported by the API).
 			{
 				Config: testAccResourceUserConfig_disabled("disabled-user", "disabled@example.com"),
 				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "username", "disabled-user"),
 					resource.TestCheckResourceAttr(resourceName, "disabled", "true"),
 				),
 			},

--- a/internal/resources/client_resource.go
+++ b/internal/resources/client_resource.go
@@ -82,10 +82,10 @@ func (r *clientResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				},
 			},
 			"client_id": schema.StringAttribute{
-				Description: "The client ID to use for the OIDC client. If not set, one will be generated.",
+				Description: "The client ID to use for the OIDC client. If not set, one will be generated. Must be between 2 and 128 characters.",
 				Optional:    true,
 				Validators: []validator.String{
-					stringvalidator.LengthBetween(3, 50), // Minimum 3 chars, maximum 50 chars
+					stringvalidator.LengthBetween(2, 128), // Matches the API binding (min=2, max=128)
 				},
 			},
 			"callback_urls": schema.ListAttribute{

--- a/internal/resources/one_time_access_token_resource.go
+++ b/internal/resources/one_time_access_token_resource.go
@@ -3,13 +3,11 @@ package resources
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework/path"
 	"github.com/hashicorp/terraform-plugin-framework/resource"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
-	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
 	"github.com/hashicorp/terraform-plugin-framework/types"
@@ -17,6 +15,9 @@ import (
 
 	"github.com/Trozz/terraform-provider-pocketid/internal/client"
 )
+
+// maxOneTimeAccessTokenTTL mirrors the pocket-id API limit (31 days).
+const maxOneTimeAccessTokenTTL = 31 * 24 * time.Hour
 
 // Ensure provider defined types fully satisfy framework interfaces
 var _ resource.Resource = &OneTimeAccessTokenResource{}
@@ -33,12 +34,12 @@ type OneTimeAccessTokenResource struct {
 
 // OneTimeAccessTokenResourceModel describes the resource data model
 type OneTimeAccessTokenResourceModel struct {
-	ID           types.String `tfsdk:"id"`
-	UserID       types.String `tfsdk:"user_id"`
-	Token        types.String `tfsdk:"token"`
-	ExpiresAt    types.String `tfsdk:"expires_at"`
-	CreatedAt    types.String `tfsdk:"created_at"`
-	SkipRecreate types.Bool   `tfsdk:"skip_recreate"`
+	ID        types.String `tfsdk:"id"`
+	UserID    types.String `tfsdk:"user_id"`
+	TTL       types.String `tfsdk:"ttl"`
+	Token     types.String `tfsdk:"token"`
+	ExpiresAt types.String `tfsdk:"expires_at"`
+	CreatedAt types.String `tfsdk:"created_at"`
 }
 
 func (r *OneTimeAccessTokenResource) Metadata(ctx context.Context, req resource.MetadataRequest, resp *resource.MetadataResponse) {
@@ -47,43 +48,43 @@ func (r *OneTimeAccessTokenResource) Metadata(ctx context.Context, req resource.
 
 func (r *OneTimeAccessTokenResource) Schema(ctx context.Context, req resource.SchemaRequest, resp *resource.SchemaResponse) {
 	resp.Schema = schema.Schema{
-		MarkdownDescription: "Manages a one-time access token for a user in Pocket-ID. These tokens allow users to authenticate when they don't have access to their passkey.",
+		MarkdownDescription: "Manages a one-time access token for a user in Pocket-ID. These tokens let a user authenticate when they don't have access to their passkey. " +
+			"The token value is returned only once on creation and cannot be read back (pocket-id exposes no read endpoint), so it is stored in Terraform state as a sensitive value.",
 		Attributes: map[string]schema.Attribute{
 			"id": schema.StringAttribute{
-				MarkdownDescription: "The unique identifier of the one-time access token (same as user_id)",
+				MarkdownDescription: "The unique identifier of the one-time access token (same as user_id).",
 				Computed:            true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.UseStateForUnknown(),
 				},
 			},
 			"user_id": schema.StringAttribute{
-				MarkdownDescription: "The ID of the user this token belongs to",
+				MarkdownDescription: "The ID of the user this token belongs to.",
 				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"ttl": schema.StringAttribute{
+				MarkdownDescription: "Lifetime of the token expressed as a Go duration string (e.g. `15m`, `1h`, `24h`). " +
+					"Must be greater than 1 second and at most 744h (31 days). Changing this forces a new token to be created.",
+				Required: true,
 				PlanModifiers: []planmodifier.String{
 					stringplanmodifier.RequiresReplace(),
 				},
 			},
 			"token": schema.StringAttribute{
-				MarkdownDescription: "The one-time access token value",
+				MarkdownDescription: "The one-time access token value. Returned only on creation.",
 				Computed:            true,
 				Sensitive:           true,
 			},
 			"expires_at": schema.StringAttribute{
-				MarkdownDescription: "The expiration time of the token in RFC3339 format",
-				Required:            true,
-				PlanModifiers: []planmodifier.String{
-					stringplanmodifier.RequiresReplace(),
-				},
+				MarkdownDescription: "The computed expiration time of the token in RFC3339 format (created_at + ttl).",
+				Computed:            true,
 			},
 			"created_at": schema.StringAttribute{
-				MarkdownDescription: "The creation time of the token in RFC3339 format",
+				MarkdownDescription: "The creation time of the token in RFC3339 format.",
 				Computed:            true,
-			},
-			"skip_recreate": schema.BoolAttribute{
-				MarkdownDescription: "If true (default), the resource will not be recreated when the token is not found (used or expired). This is useful for initial user setup where the token is sent via another provider. Note: Setting this to false will enable standard Terraform behavior, where the resource is recreated if the token is missing.",
-				Optional:            true,
-				Computed:            true,
-				Default:             booldefault.StaticBool(true),
 			},
 		},
 	}
@@ -115,38 +116,32 @@ func (r *OneTimeAccessTokenResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	// Prepare the request
-	tokenReq := &client.OneTimeAccessTokenRequest{}
-
-	// Parse expires_at (now required)
-	expiresAtStr := data.ExpiresAt.ValueString()
-	tflog.Debug(ctx, "expires_at value from plan", map[string]interface{}{
-		"expires_at": expiresAtStr,
-	})
-
-	expiresAt, err := time.Parse(time.RFC3339, expiresAtStr)
+	// Validate the ttl duration up front to give a clear error before calling the API.
+	ttlStr := data.TTL.ValueString()
+	ttl, err := time.ParseDuration(ttlStr)
 	if err != nil {
-		resp.Diagnostics.AddError(
-			"Invalid expires_at format",
-			fmt.Sprintf("The expires_at value must be in RFC3339 format: %s", err),
+		resp.Diagnostics.AddAttributeError(
+			path.Root("ttl"),
+			"Invalid ttl",
+			fmt.Sprintf("The ttl value must be a Go duration string such as \"15m\" or \"1h\": %s", err),
 		)
 		return
 	}
-	tokenReq.ExpiresAt = &expiresAt
+	if ttl <= time.Second || ttl > maxOneTimeAccessTokenTTL {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("ttl"),
+			"Invalid ttl",
+			"The ttl must be greater than 1 second and at most 744h (31 days).",
+		)
+		return
+	}
 
-	// Create the token
 	tflog.Debug(ctx, "creating one-time access token", map[string]interface{}{
-		"user_id":        data.UserID.ValueString(),
-		"expires_at_set": tokenReq.ExpiresAt != nil,
-		"expires_at_value": func() string {
-			if tokenReq.ExpiresAt != nil {
-				return tokenReq.ExpiresAt.Format(time.RFC3339)
-			}
-			return "nil"
-		}(),
+		"user_id": data.UserID.ValueString(),
+		"ttl":     ttlStr,
 	})
 
-	token, err := r.client.CreateOneTimeAccessToken(data.UserID.ValueString(), tokenReq)
+	token, err := r.client.CreateOneTimeAccessToken(data.UserID.ValueString(), &client.OneTimeAccessTokenRequest{TTL: ttlStr})
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error creating one-time access token",
@@ -155,13 +150,12 @@ func (r *OneTimeAccessTokenResource) Create(ctx context.Context, req resource.Cr
 		return
 	}
 
-	// Map response to model
+	// The API only returns the token value, so derive the remaining attributes locally.
+	created := time.Now().UTC()
 	data.ID = data.UserID
 	data.Token = types.StringValue(token.Token)
-	// The API only returns the token, not the full object, so we preserve the values from the request
-	// ExpiresAt is already set from the plan
-	// Set CreatedAt to now since the API doesn't return it
-	data.CreatedAt = types.StringValue(time.Now().UTC().Format(time.RFC3339))
+	data.CreatedAt = types.StringValue(created.Format(time.RFC3339))
+	data.ExpiresAt = types.StringValue(created.Add(ttl).Format(time.RFC3339))
 
 	tflog.Trace(ctx, "created one-time access token", map[string]interface{}{
 		"user_id": data.UserID.ValueString(),
@@ -180,65 +174,17 @@ func (r *OneTimeAccessTokenResource) Read(ctx context.Context, req resource.Read
 		return
 	}
 
-	// Get current token state
-	tflog.Trace(ctx, "reading one-time access token", map[string]interface{}{
+	// pocket-id exposes no endpoint to read a one-time access token back, and the
+	// token is consumed on use. There is nothing to refresh, so the prior state is
+	// preserved as-is.
+	tflog.Trace(ctx, "one-time access token is write-only, preserving state", map[string]interface{}{
 		"user_id": data.UserID.ValueString(),
 	})
-
-	_, err := r.client.GetOneTimeAccessToken(data.UserID.ValueString())
-	if err != nil {
-		// pocket-id v2 removed the GET one-time-access-token endpoint. When the
-		// endpoint itself is unavailable we cannot determine the token's state,
-		// so preserve the resource in state rather than churning it on every plan.
-		if strings.Contains(err.Error(), "API endpoint not found") {
-			tflog.Debug(ctx, "One-time access token GET endpoint unavailable, preserving resource in state")
-			resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-			return
-		}
-		// If the token is not found
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			// Check if we should skip recreation
-			// Default to true if not set
-			skipRecreate := true
-			if !data.SkipRecreate.IsNull() && !data.SkipRecreate.IsUnknown() {
-				skipRecreate = data.SkipRecreate.ValueBool()
-			}
-
-			if skipRecreate {
-				// Keep the resource in state but clear sensitive values
-				// This prevents Terraform from trying to recreate it
-				tflog.Debug(ctx, "Token not found but skip_recreate is true, maintaining resource in state")
-
-				// Clear the token value since it's no longer valid
-				data.Token = types.StringValue("")
-
-				// Save the updated state
-				resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
-				return
-			}
-
-			// Otherwise, remove it from state to trigger recreation
-			resp.State.RemoveResource(ctx)
-			return
-		}
-
-		resp.Diagnostics.AddError(
-			"Error reading one-time access token",
-			fmt.Sprintf("Could not read one-time access token for user %s: %s", data.UserID.ValueString(), err),
-		)
-		return
-	}
-
-	// The GET endpoint doesn't return the full token details, only confirms it exists
-	// We keep the existing state values since they don't change
-	// The token value is sensitive and not returned on GET for security
-
-	// Save updated data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }
 
 func (r *OneTimeAccessTokenResource) Update(ctx context.Context, req resource.UpdateRequest, resp *resource.UpdateResponse) {
-	// One-time access tokens cannot be updated
+	// All configurable attributes force replacement, so Update is never expected to run.
 	resp.Diagnostics.AddError(
 		"Update not supported",
 		"One-time access tokens cannot be updated. To change a token, delete and recreate it.",
@@ -246,45 +192,13 @@ func (r *OneTimeAccessTokenResource) Update(ctx context.Context, req resource.Up
 }
 
 func (r *OneTimeAccessTokenResource) Delete(ctx context.Context, req resource.DeleteRequest, resp *resource.DeleteResponse) {
-	var data OneTimeAccessTokenResourceModel
-
-	// Read Terraform prior state data into the model
-	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
-	if resp.Diagnostics.HasError() {
-		return
-	}
-
-	// Delete the token
-	tflog.Trace(ctx, "deleting one-time access token", map[string]interface{}{
-		"user_id": data.UserID.ValueString(),
-	})
-
-	err := r.client.DeleteOneTimeAccessToken(data.UserID.ValueString())
-	if err != nil {
-		// If the token is already gone, consider it deleted
-		if strings.Contains(err.Error(), "404") || strings.Contains(err.Error(), "not found") {
-			return
-		}
-
-		resp.Diagnostics.AddError(
-			"Error deleting one-time access token",
-			fmt.Sprintf("Could not delete one-time access token for user %s: %s", data.UserID.ValueString(), err),
-		)
-		return
-	}
-
-	tflog.Trace(ctx, "deleted one-time access token", map[string]interface{}{
-		"user_id": data.UserID.ValueString(),
-	})
+	// pocket-id exposes no endpoint to revoke a one-time access token; it remains
+	// valid until used or expired. Removing it from Terraform state is all we can do.
+	tflog.Trace(ctx, "one-time access token cannot be revoked via API, removing from state only")
 }
 
 func (r *OneTimeAccessTokenResource) ImportState(ctx context.Context, req resource.ImportStateRequest, resp *resource.ImportStateResponse) {
-	// Import by user ID
+	// Import by user ID. The token value cannot be recovered from the API.
 	resource.ImportStatePassthroughID(ctx, path.Root("user_id"), req, resp)
-
-	// Also set the ID
 	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("id"), req.ID)...)
-
-	// Set skip_recreate to true by default on import
-	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("skip_recreate"), true)...)
 }

--- a/internal/resources/one_time_access_token_resource_test.go
+++ b/internal/resources/one_time_access_token_resource_test.go
@@ -2,7 +2,6 @@ package resources_test
 
 import (
 	"context"
-	"net/http"
 	"testing"
 
 	"github.com/hashicorp/terraform-plugin-framework/resource"
@@ -45,12 +44,14 @@ func TestOneTimeAccessTokenResource_Schema(t *testing.T) {
 	schema := resp.Schema
 	assert.NotNil(t, schema)
 
-	// Check required attributes
+	// Check attributes
 	assert.Contains(t, schema.Attributes, "id")
 	assert.Contains(t, schema.Attributes, "user_id")
+	assert.Contains(t, schema.Attributes, "ttl")
 	assert.Contains(t, schema.Attributes, "token")
 	assert.Contains(t, schema.Attributes, "expires_at")
 	assert.Contains(t, schema.Attributes, "created_at")
+	assert.NotContains(t, schema.Attributes, "skip_recreate")
 
 	// Verify attribute properties
 	idAttr := schema.Attributes["id"]
@@ -61,23 +62,21 @@ func TestOneTimeAccessTokenResource_Schema(t *testing.T) {
 	assert.True(t, userIDAttr.IsRequired())
 	assert.False(t, userIDAttr.IsComputed())
 
+	ttlAttr := schema.Attributes["ttl"]
+	assert.True(t, ttlAttr.IsRequired())
+	assert.False(t, ttlAttr.IsComputed())
+
 	tokenAttr := schema.Attributes["token"]
 	assert.True(t, tokenAttr.IsComputed())
 	assert.True(t, tokenAttr.IsSensitive())
 
 	expiresAtAttr := schema.Attributes["expires_at"]
-	assert.True(t, expiresAtAttr.IsRequired())
-	assert.False(t, expiresAtAttr.IsComputed())
+	assert.True(t, expiresAtAttr.IsComputed())
+	assert.False(t, expiresAtAttr.IsRequired())
 
 	createdAtAttr := schema.Attributes["created_at"]
 	assert.True(t, createdAtAttr.IsComputed())
 	assert.False(t, createdAtAttr.IsRequired())
-
-	// Check skip_recreate attribute
-	skipRecreateAttr := schema.Attributes["skip_recreate"]
-	assert.True(t, skipRecreateAttr.IsOptional())
-	assert.False(t, skipRecreateAttr.IsRequired())
-	assert.True(t, skipRecreateAttr.IsComputed())
 }
 
 func TestOneTimeAccessTokenResource_Configure(t *testing.T) {
@@ -122,107 +121,59 @@ func TestOneTimeAccessTokenResource_Configure(t *testing.T) {
 	}
 }
 
-// readWithGetHandler configures a one-time access token resource against a mock
-// server, seeds prior state, and invokes Read. It returns the Read response so
-// tests can assert on the resulting state.
-func readWithGetHandler(t *testing.T, prior resources.OneTimeAccessTokenResourceModel, handler http.HandlerFunc) *resource.ReadResponse {
-	t.Helper()
-	ctx := context.Background()
+func samplePriorTokenState() resources.OneTimeAccessTokenResourceModel {
+	return resources.OneTimeAccessTokenResourceModel{
+		ID:        types.StringValue("user-123"),
+		UserID:    types.StringValue("user-123"),
+		TTL:       types.StringValue("15m"),
+		Token:     types.StringValue("ABC123"),
+		ExpiresAt: types.StringValue("2026-01-01T00:15:00Z"),
+		CreatedAt: types.StringValue("2026-01-01T00:00:00Z"),
+	}
+}
 
-	testClient := createMockServer(t, handler)
+// One-time access tokens are write-only (pocket-id exposes no read endpoint),
+// so Read must preserve prior state verbatim without contacting the API.
+func TestOneTimeAccessTokenResource_Read_PreservesState(t *testing.T) {
+	ctx := context.Background()
 	r, ok := resources.NewOneTimeAccessTokenResource().(*resources.OneTimeAccessTokenResource)
 	require.True(t, ok)
-
-	configResp := &resource.ConfigureResponse{}
-	r.Configure(ctx, resource.ConfigureRequest{ProviderData: testClient}, configResp)
-	require.False(t, configResp.Diagnostics.HasError())
 
 	schemaResp := &resource.SchemaResponse{}
 	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
 
+	prior := samplePriorTokenState()
 	state := tfsdk.State{Schema: schemaResp.Schema}
 	require.False(t, state.Set(ctx, &prior).HasError())
 
 	resp := &resource.ReadResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
 	r.Read(ctx, resource.ReadRequest{State: state}, resp)
-	return resp
-}
 
-func samplePriorTokenState(skipRecreate bool) resources.OneTimeAccessTokenResourceModel {
-	return resources.OneTimeAccessTokenResourceModel{
-		ID:           types.StringValue("user-123"),
-		UserID:       types.StringValue("user-123"),
-		Token:        types.StringValue("ABC123"),
-		ExpiresAt:    types.StringValue("2026-12-01T00:00:00Z"),
-		CreatedAt:    types.StringValue("2026-01-01T00:00:00Z"),
-		SkipRecreate: types.BoolValue(skipRecreate),
-	}
-}
-
-// pocket-id v2 removed the GET endpoint and responds with "API endpoint not
-// found". Read must preserve the resource (including its token) rather than
-// removing it from state.
-func TestOneTimeAccessTokenResource_Read_EndpointNotFound(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":"API endpoint not found"}`))
-	}
-
-	resp := readWithGetHandler(t, samplePriorTokenState(false), handler)
 	require.False(t, resp.Diagnostics.HasError())
 	require.False(t, resp.State.Raw.IsNull(), "resource should be preserved in state")
 
 	var got resources.OneTimeAccessTokenResourceModel
-	require.False(t, resp.State.Get(context.Background(), &got).HasError())
+	require.False(t, resp.State.Get(ctx, &got).HasError())
 	assert.Equal(t, "user-123", got.UserID.ValueString())
+	assert.Equal(t, "15m", got.TTL.ValueString())
 	assert.Equal(t, "ABC123", got.Token.ValueString(), "token should be preserved")
+	assert.Equal(t, "2026-01-01T00:15:00Z", got.ExpiresAt.ValueString())
 }
 
-// When the token is genuinely gone and skip_recreate is true, Read keeps the
-// resource in state but clears the now-invalid token value.
-func TestOneTimeAccessTokenResource_Read_TokenNotFound_SkipRecreate(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":"One-time access token not found"}`))
-	}
+// Delete has no API endpoint to call, so it must succeed without error.
+func TestOneTimeAccessTokenResource_Delete_NoOp(t *testing.T) {
+	ctx := context.Background()
+	r, ok := resources.NewOneTimeAccessTokenResource().(*resources.OneTimeAccessTokenResource)
+	require.True(t, ok)
 
-	resp := readWithGetHandler(t, samplePriorTokenState(true), handler)
-	require.False(t, resp.Diagnostics.HasError())
-	require.False(t, resp.State.Raw.IsNull(), "resource should be preserved in state")
+	schemaResp := &resource.SchemaResponse{}
+	r.Schema(ctx, resource.SchemaRequest{}, schemaResp)
 
-	var got resources.OneTimeAccessTokenResourceModel
-	require.False(t, resp.State.Get(context.Background(), &got).HasError())
-	assert.Equal(t, "user-123", got.UserID.ValueString())
-	assert.Equal(t, "", got.Token.ValueString(), "token should be cleared")
-}
+	prior := samplePriorTokenState()
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	require.False(t, state.Set(ctx, &prior).HasError())
 
-// When the token is gone and skip_recreate is false, Read removes the resource
-// from state so Terraform recreates it.
-func TestOneTimeAccessTokenResource_Read_TokenNotFound_NoSkipRecreate(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = w.Write([]byte(`{"error":"One-time access token not found"}`))
-	}
-
-	resp := readWithGetHandler(t, samplePriorTokenState(false), handler)
-	require.False(t, resp.Diagnostics.HasError())
-	assert.True(t, resp.State.Raw.IsNull(), "resource should be removed from state")
-}
-
-// When the token still exists, Read succeeds and retains the existing state.
-func TestOneTimeAccessTokenResource_Read_Success(t *testing.T) {
-	handler := func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	}
-
-	resp := readWithGetHandler(t, samplePriorTokenState(false), handler)
-	require.False(t, resp.Diagnostics.HasError())
-	require.False(t, resp.State.Raw.IsNull())
-
-	var got resources.OneTimeAccessTokenResourceModel
-	require.False(t, resp.State.Get(context.Background(), &got).HasError())
-	assert.Equal(t, "ABC123", got.Token.ValueString())
+	resp := &resource.DeleteResponse{State: tfsdk.State{Schema: schemaResp.Schema}}
+	r.Delete(ctx, resource.DeleteRequest{State: state}, resp)
+	assert.False(t, resp.Diagnostics.HasError())
 }

--- a/internal/resources/user_resource.go
+++ b/internal/resources/user_resource.go
@@ -108,7 +108,7 @@ func (r *userResource) Schema(_ context.Context, _ resource.SchemaRequest, resp 
 				Optional:    true,
 			},
 			"disabled": schema.BoolAttribute{
-				Description: "Whether the user account is disabled. Defaults to false. Note: Due to API limitations, this field cannot be set during user creation. To create a disabled user, first create the user and then update it to set disabled to true.",
+				Description: "Whether the user account is disabled. Defaults to false.",
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
@@ -172,7 +172,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 		LastName:    plan.LastName.ValueString(),
 		DisplayName: displayName,
 		IsAdmin:     plan.IsAdmin.ValueBool(),
-		// Don't set Disabled during creation as the API doesn't support it
+		Disabled:    plan.Disabled.ValueBool(),
 	}
 
 	// Handle locale if provided
@@ -209,18 +209,7 @@ func (r *userResource) Create(ctx context.Context, req resource.CreateRequest, r
 	plan.DisplayName = types.StringValue(userResp.DisplayName)
 	plan.IsAdmin = types.BoolValue(userResp.IsAdmin)
 
-	// The API always returns disabled=false for newly created users, regardless of the request
-	// If the plan requested disabled=true, we need to inform the user about this limitation
-	if plan.Disabled.ValueBool() && !userResp.Disabled {
-		resp.Diagnostics.AddWarning(
-			"API Limitation",
-			"The Pocket-ID API does not support creating disabled users. The user was created but remains enabled. To disable the user, please run 'terraform apply' again or update the user manually.",
-		)
-		// Set the actual value from the API to maintain consistency
-		plan.Disabled = types.BoolValue(false)
-	} else {
-		plan.Disabled = types.BoolValue(userResp.Disabled)
-	}
+	plan.Disabled = types.BoolValue(userResp.Disabled)
 
 	// Handle locale
 	if userResp.Locale != nil && *userResp.Locale != "" {

--- a/templates/resources/one_time_access_token.md.tmpl
+++ b/templates/resources/one_time_access_token.md.tmpl
@@ -13,16 +13,10 @@ description: |-
 ## Example Usage
 
 ```terraform
-# Create a one-time access token for a user (expires_at is required)
+# Create a one-time access token for a user, valid for 1 hour
 resource "pocketid_one_time_access_token" "example" {
-  user_id    = pocketid_user.example.id
-  expires_at = timeadd(timestamp(), "24h") # Token expires in 24 hours
-}
-
-# Create a one-time access token with custom expiry (1 hour from now)
-resource "pocketid_one_time_access_token" "temporary" {
-  user_id    = pocketid_user.example.id
-  expires_at = timeadd(timestamp(), "1h")
+  user_id = pocketid_user.example.id
+  ttl     = "1h"
 }
 
 # Example with user creation
@@ -40,7 +34,7 @@ output "access_token" {
   sensitive   = true
 }
 
-# Use case: Create a token for emergency access
+# Use case: Create a token for emergency access, valid for 24 hours
 resource "pocketid_user" "emergency" {
   username   = "emergency.access"
   email      = "emergency@example.com"
@@ -50,16 +44,16 @@ resource "pocketid_user" "emergency" {
 }
 
 resource "pocketid_one_time_access_token" "emergency" {
-  user_id    = pocketid_user.emergency.id
-  expires_at = timeadd(timestamp(), "24h") # Valid for 24 hours
+  user_id = pocketid_user.emergency.id
+  ttl     = "24h"
 }
 
 # Note: One-time access tokens are useful when users need to authenticate
 # from a device where they don't have access to their passkey.
-# The token can only be used once and should be treated as a secret.
+# The token can only be used once and should be treated as a secret. Its value
+# is returned only on creation and cannot be read back from the API.
 
-# Use case: Initial user setup with skip_recreate
-# This prevents Terraform from recreating the token after it's been used
+# Use case: Initial user setup, token valid for 7 days
 resource "pocketid_user" "new_user" {
   username   = "new.employee"
   email      = "new.employee@company.com"
@@ -68,9 +62,8 @@ resource "pocketid_user" "new_user" {
 }
 
 resource "pocketid_one_time_access_token" "onboarding" {
-  user_id       = pocketid_user.new_user.id
-  expires_at    = timeadd(timestamp(), "168h") # Valid for 7 days
-  skip_recreate = true                         # Don't recreate if token is used
+  user_id = pocketid_user.new_user.id
+  ttl     = "168h" # 7 days (max ttl is 744h / 31 days)
 }
 
 # Send the token via another provider (e.g., email, SMS)

--- a/tests/terraform-resources/main.tf
+++ b/tests/terraform-resources/main.tf
@@ -71,15 +71,13 @@ resource "pocketid_user" "disabled_user" {
 
 # One-time access tokens
 resource "pocketid_one_time_access_token" "admin_token" {
-  user_id       = pocketid_user.admin_user.id
-  expires_at    = timeadd(timestamp(), "24h")
-  skip_recreate = true
+  user_id = pocketid_user.admin_user.id
+  ttl     = "24h"
 }
 
 resource "pocketid_one_time_access_token" "dev_token" {
-  user_id       = pocketid_user.dev_user.id
-  expires_at    = timeadd(timestamp(), "1h")
-  skip_recreate = false
+  user_id = pocketid_user.dev_user.id
+  ttl     = "1h"
 }
 
 # OAuth2 Clients


### PR DESCRIPTION
## Summary

Correctness fixes found by auditing the provider against the pocket-id v2 application source. Includes one breaking change to `pocketid_one_time_access_token`, intended for a **v0.2.0** release.

### Fixes
- **`client_id` validator** (`fix`): the provider rejected client IDs the API accepts. It validated `LengthBetween(3, 50)`; the API binding is `min=2, max=128`. Widened the validator and corrected the description.
- **User `disabled` on create** (`fix`): `UserCreateDto` supports `disabled` and the create service honors it, but the provider dropped it on create and emitted a false "API does not support creating disabled users" warning. Now sent on create; warning removed.
- **One-time access token `ttl`** (`feat!`, **breaking**): pocket-id v2 creates these with a `ttl` duration (not an absolute expiry) and exposes **no GET or DELETE** endpoint. The provider previously sent an ignored `expiresAt` field and called non-existent read/delete endpoints, so the operator's `expires_at` was silently ignored.
  - `expires_at` (input) → **`ttl`** (required duration string, e.g. `15m`, `1h`; max `744h`). `expires_at` is now a **computed** output (`created_at + ttl`).
  - **Removed `skip_recreate`** — it depended on a read endpoint that no longer exists.
  - `Read` is now state-only (the token is write-only and can't be re-read); `Delete` is a no-op (no revoke endpoint). Dropped the unused `Get`/`Delete` client methods.

### Breaking changes
- `pocketid_one_time_access_token`: **`expires_at` (input) → `ttl`**, and **`skip_recreate` removed**.

  Migration:
  ```diff
  resource "pocketid_one_time_access_token" "example" {
    user_id       = pocketid_user.example.id
  -  expires_at    = timeadd(timestamp(), "1h")
  -  skip_recreate = true
  +  ttl           = "1h"
  }
  ```

## Validation
- Audited each field/endpoint against pocket-id v2.8.0 source.
- `go build`, `go vet -tags acc`, `golangci-lint` (0 issues), `gofmt`, `terraform fmt` all clean.
- Unit tests updated; acceptance tests (`ttl`, disabled-on-create, client) pass against a live pocket-id v2.8.0.
- Docs regenerated via `tfplugindocs`; examples and the doc template updated.