### PR TITLE
fix(ci): pin goreleaser to pushed tag to avoid dev-tag collision

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,9 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}
           PASSPHRASE: ${{ secrets.PASSPHRASE }}
+          # Pin GoReleaser to the pushed tag so a dev pre-release tag on the
+          # same commit can't win `git describe` and publish the wrong version.
+          GORELEASER_CURRENT_TAG: ${{ github.ref_name }}
 
       - name: Generate release attestations
         uses: actions/attest-build-provenance@a2bbfa25375fe432b6a289bc6b6cd05ecd0c4c32 # v4.1.0


### PR DESCRIPTION
## Problem

The `Release` workflow can publish the wrong version. The `Pre-release` workflow tags every `main` commit with a dev tag (e.g. `v0.1.8-dev.<ts>+<sha>`). When a release tag `vX.Y.Z` later lands on that same commit, both tags point to one commit and GoReleaser's `git describe --tags` can pick the dev tag, publishing a prerelease instead of the real release.

This happened with `v0.1.8`: the run reported success but only updated the dev prerelease, so no `v0.1.8` release was created and the Terraform Registry never ingested it.

## Fix

Set `GORELEASER_CURRENT_TAG: ${{ github.ref_name }}` on the GoReleaser step so it always uses the exact pushed tag, ignoring any other tag on the same commit.