### PR TITLE
feat(client): add requires_pushed_authorization_requests (PAR)

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -102,10 +102,11 @@ resource "pocketid_client" "admin_portal" {
     "https://admin.example.com/logout"
   ]
 
-  is_public                 = false
-  pkce_enabled              = true
-  requires_reauthentication = true
-  launch_url                = "https://admin.example.com"
+  is_public                              = false
+  pkce_enabled                           = true
+  requires_reauthentication              = true
+  requires_pushed_authorization_requests = true
+  launch_url                             = "https://admin.example.com"
 
   # Only admins and developers can access this client
   allowed_user_groups = [
@@ -173,6 +174,7 @@ output "spa_client_id" {
 - `launch_url` (String) Optional launch URL associated with the client.
 - `logout_callback_urls` (List of String) List of allowed logout callback URLs for the OIDC client.
 - `pkce_enabled` (Boolean) Whether PKCE is enabled for this client. Defaults to true.
+- `requires_pushed_authorization_requests` (Boolean) Whether this client requires Pushed Authorization Requests (PAR, RFC 9126). Defaults to false. Note: this is enforced only by Pocket-ID versions that support PAR (added after v2.8.0); on older servers the value is stored in state but not enforced.
 - `requires_reauthentication` (Boolean) Whether this client requires reauthentication for certain flows. Defaults to false.
 
 ### Read-Only

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -22,19 +22,22 @@ type PaginatedResponse[T any] struct {
 
 // OIDCClient represents an OIDC client in Pocket-ID
 type OIDCClient struct {
-	ID                       string                `json:"id,omitempty"`
-	Name                     string                `json:"name"`
-	HasLogo                  bool                  `json:"hasLogo,omitempty"`
-	CallbackURLs             []string              `json:"callbackURLs"`
-	LogoutCallbackURLs       []string              `json:"logoutCallbackURLs,omitempty"`
-	IsPublic                 bool                  `json:"isPublic"`
-	RequiresReauthentication bool                  `json:"requiresReauthentication,omitempty"`
-	LaunchURL                string                `json:"launchURL,omitempty"`
-	PkceEnabled              bool                  `json:"pkceEnabled"`
-	IsGroupRestricted        bool                  `json:"isGroupRestricted"`
-	Credentials              OIDCClientCredentials `json:"credentials"`
-	AllowedUserGroups        []UserGroup           `json:"allowedUserGroups,omitempty"`
-	AllowedUserGroupsCount   int64                 `json:"allowedUserGroupsCount,omitempty"`
+	ID                       string   `json:"id,omitempty"`
+	Name                     string   `json:"name"`
+	HasLogo                  bool     `json:"hasLogo,omitempty"`
+	CallbackURLs             []string `json:"callbackURLs"`
+	LogoutCallbackURLs       []string `json:"logoutCallbackURLs,omitempty"`
+	IsPublic                 bool     `json:"isPublic"`
+	RequiresReauthentication bool     `json:"requiresReauthentication,omitempty"`
+	// Pointer so an absent field (Pocket-ID <= v2.8.0, which has no PAR support)
+	// is distinguishable from an explicit false.
+	RequiresPushedAuthorizationRequests *bool                 `json:"requiresPushedAuthorizationRequests,omitempty"`
+	LaunchURL                           string                `json:"launchURL,omitempty"`
+	PkceEnabled                         bool                  `json:"pkceEnabled"`
+	IsGroupRestricted                   bool                  `json:"isGroupRestricted"`
+	Credentials                         OIDCClientCredentials `json:"credentials"`
+	AllowedUserGroups                   []UserGroup           `json:"allowedUserGroups,omitempty"`
+	AllowedUserGroupsCount              int64                 `json:"allowedUserGroupsCount,omitempty"`
 }
 
 // OIDCClientCredentials represents federated identity credentials for an OIDC client
@@ -52,16 +55,17 @@ type OIDCClientFederatedIdentity struct {
 
 // OIDCClientCreateRequest represents a request to create or update an OIDC client
 type OIDCClientCreateRequest struct {
-	Name                     string                `json:"name"`
-	ClientID                 *string               `json:"id,omitempty"`
-	CallbackURLs             []string              `json:"callbackURLs"`
-	LogoutCallbackURLs       []string              `json:"logoutCallbackURLs,omitempty"`
-	IsPublic                 bool                  `json:"isPublic"`
-	RequiresReauthentication bool                  `json:"requiresReauthentication,omitempty"`
-	LaunchURL                *string               `json:"launchURL,omitempty"`
-	PkceEnabled              bool                  `json:"pkceEnabled"`
-	IsGroupRestricted        bool                  `json:"isGroupRestricted"`
-	Credentials              OIDCClientCredentials `json:"credentials"`
+	Name                                string                `json:"name"`
+	ClientID                            *string               `json:"id,omitempty"`
+	CallbackURLs                        []string              `json:"callbackURLs"`
+	LogoutCallbackURLs                  []string              `json:"logoutCallbackURLs,omitempty"`
+	IsPublic                            bool                  `json:"isPublic"`
+	RequiresReauthentication            bool                  `json:"requiresReauthentication,omitempty"`
+	RequiresPushedAuthorizationRequests bool                  `json:"requiresPushedAuthorizationRequests"`
+	LaunchURL                           *string               `json:"launchURL,omitempty"`
+	PkceEnabled                         bool                  `json:"pkceEnabled"`
+	IsGroupRestricted                   bool                  `json:"isGroupRestricted"`
+	Credentials                         OIDCClientCredentials `json:"credentials"`
 }
 
 // ClientSecretResponse represents the response when generating a client secret

--- a/internal/provider/resource_client_test.go
+++ b/internal/provider/resource_client_test.go
@@ -387,3 +387,42 @@ func testAccCheckClientSecretNotEmpty(resourceName string) resource.TestCheckFun
 		return nil
 	}
 }
+
+func TestAccResourceClient_requiresPushedAuthorizationRequests(t *testing.T) {
+	resourceName := "pocketid_client.test"
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			// Set PAR to true. On Pocket-ID <= v2.8.0 the API does not echo the
+			// field, so the provider preserves the configured value (no
+			// inconsistent-result error, no perpetual diff).
+			{
+				Config: testAccResourceClientConfig_par("par-client", true),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "requires_pushed_authorization_requests", "true"),
+				),
+			},
+			// Flip it back to false and confirm it applies cleanly.
+			{
+				Config: testAccResourceClientConfig_par("par-client", false),
+				Check: resource.ComposeAggregateTestCheckFunc(
+					resource.TestCheckResourceAttr(resourceName, "requires_pushed_authorization_requests", "false"),
+				),
+			},
+		},
+	})
+}
+
+func testAccResourceClientConfig_par(name string, par bool) string {
+	return testAccProviderConfig() + fmt.Sprintf(`
+resource "pocketid_client" "test" {
+  name          = %[1]q
+  callback_urls = ["https://example.com/callback"]
+  is_public     = true
+
+  requires_pushed_authorization_requests = %[2]t
+}
+`, name, par)
+}

--- a/internal/resources/client_resource.go
+++ b/internal/resources/client_resource.go
@@ -41,19 +41,20 @@ type clientResource struct {
 
 // clientResourceModel maps the resource schema data.
 type clientResourceModel struct {
-	ID                       types.String `tfsdk:"id"`
-	Name                     types.String `tfsdk:"name"`
-	ClientID                 types.String `tfsdk:"client_id"`
-	CallbackURLs             types.List   `tfsdk:"callback_urls"`
-	LogoutCallbackURLs       types.List   `tfsdk:"logout_callback_urls"`
-	IsPublic                 types.Bool   `tfsdk:"is_public"`
-	PkceEnabled              types.Bool   `tfsdk:"pkce_enabled"`
-	AllowedUserGroups        types.List   `tfsdk:"allowed_user_groups"`
-	HasLogo                  types.Bool   `tfsdk:"has_logo"`
-	RequiresReauthentication types.Bool   `tfsdk:"requires_reauthentication"`
-	LaunchURL                types.String `tfsdk:"launch_url"`
-	FederatedIdentities      types.List   `tfsdk:"federated_identities"`
-	ClientSecret             types.String `tfsdk:"client_secret"`
+	ID                                  types.String `tfsdk:"id"`
+	Name                                types.String `tfsdk:"name"`
+	ClientID                            types.String `tfsdk:"client_id"`
+	CallbackURLs                        types.List   `tfsdk:"callback_urls"`
+	LogoutCallbackURLs                  types.List   `tfsdk:"logout_callback_urls"`
+	IsPublic                            types.Bool   `tfsdk:"is_public"`
+	PkceEnabled                         types.Bool   `tfsdk:"pkce_enabled"`
+	AllowedUserGroups                   types.List   `tfsdk:"allowed_user_groups"`
+	HasLogo                             types.Bool   `tfsdk:"has_logo"`
+	RequiresReauthentication            types.Bool   `tfsdk:"requires_reauthentication"`
+	RequiresPushedAuthorizationRequests types.Bool   `tfsdk:"requires_pushed_authorization_requests"`
+	LaunchURL                           types.String `tfsdk:"launch_url"`
+	FederatedIdentities                 types.List   `tfsdk:"federated_identities"`
+	ClientSecret                        types.String `tfsdk:"client_secret"`
 }
 
 // clientFederatedIdentityModel maps a single federated identity nested object.
@@ -133,6 +134,13 @@ func (r *clientResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 				Optional:    true,
 				Computed:    true,
 				Default:     booldefault.StaticBool(false),
+			},
+			"requires_pushed_authorization_requests": schema.BoolAttribute{
+				Description: "Whether this client requires Pushed Authorization Requests (PAR, RFC 9126). Defaults to false. " +
+					"Note: this is enforced only by Pocket-ID versions that support PAR (added after v2.8.0); on older servers the value is stored in state but not enforced.",
+				Optional: true,
+				Computed: true,
+				Default:  booldefault.StaticBool(false),
 			},
 			"launch_url": schema.StringAttribute{
 				Description: "Optional launch URL associated with the client.",
@@ -265,6 +273,11 @@ func (r *clientResource) Create(ctx context.Context, req resource.CreateRequest,
 	plan.RequiresReauthentication = apiModel.RequiresReauthentication
 	plan.FederatedIdentities = apiModel.FederatedIdentities
 	plan.LaunchURL = apiModel.LaunchURL
+	// Preserve the configured PAR value when the server does not return the field
+	// (Pocket-ID <= v2.8.0). Only override from the API when it is present.
+	if clientResp.RequiresPushedAuthorizationRequests != nil {
+		plan.RequiresPushedAuthorizationRequests = types.BoolValue(*clientResp.RequiresPushedAuthorizationRequests)
+	}
 
 	// Generate client secret for non-public clients
 	if !plan.IsPublic.ValueBool() {
@@ -341,6 +354,14 @@ func (r *clientResource) Read(ctx context.Context, req resource.ReadRequest, res
 	state.PkceEnabled = types.BoolValue(clientResp.PkceEnabled)
 	state.HasLogo = types.BoolValue(clientResp.HasLogo)
 	state.RequiresReauthentication = types.BoolValue(clientResp.RequiresReauthentication)
+	// Only refresh PAR from the API when the server returns the field; otherwise
+	// preserve the existing state value (Pocket-ID <= v2.8.0 omits it). On import
+	// there is no prior value, so fall back to the default of false.
+	if clientResp.RequiresPushedAuthorizationRequests != nil {
+		state.RequiresPushedAuthorizationRequests = types.BoolValue(*clientResp.RequiresPushedAuthorizationRequests)
+	} else if state.RequiresPushedAuthorizationRequests.IsNull() || state.RequiresPushedAuthorizationRequests.IsUnknown() {
+		state.RequiresPushedAuthorizationRequests = types.BoolValue(false)
+	}
 	state.FederatedIdentities = federatedIdentitiesToList(ctx, clientResp.Credentials.FederatedIdentities)
 	if clientResp.LaunchURL != "" {
 		state.LaunchURL = types.StringValue(clientResp.LaunchURL)
@@ -423,11 +444,12 @@ func (r *clientResource) Update(ctx context.Context, req resource.UpdateRequest,
 
 	// Update the client
 	updateReq := &client.OIDCClientCreateRequest{
-		Name:                     plan.Name.ValueString(),
-		CallbackURLs:             callbackURLs,
-		LogoutCallbackURLs:       logoutCallbackURLs,
-		IsPublic:                 plan.IsPublic.ValueBool(),
-		RequiresReauthentication: plan.RequiresReauthentication.ValueBool(),
+		Name:                                plan.Name.ValueString(),
+		CallbackURLs:                        callbackURLs,
+		LogoutCallbackURLs:                  logoutCallbackURLs,
+		IsPublic:                            plan.IsPublic.ValueBool(),
+		RequiresReauthentication:            plan.RequiresReauthentication.ValueBool(),
+		RequiresPushedAuthorizationRequests: plan.RequiresPushedAuthorizationRequests.ValueBool(),
 		LaunchURL: func() *string {
 			if !plan.LaunchURL.IsNull() && !plan.LaunchURL.IsUnknown() && plan.LaunchURL.ValueString() != "" {
 				v := plan.LaunchURL.ValueString()
@@ -462,6 +484,10 @@ func (r *clientResource) Update(ctx context.Context, req resource.UpdateRequest,
 	plan.HasLogo = types.BoolValue(clientResp.HasLogo)
 	plan.RequiresReauthentication = types.BoolValue(clientResp.RequiresReauthentication)
 	plan.FederatedIdentities = federatedIdentitiesToList(ctx, clientResp.Credentials.FederatedIdentities)
+	// Preserve the configured PAR value unless the server returns the field.
+	if clientResp.RequiresPushedAuthorizationRequests != nil {
+		plan.RequiresPushedAuthorizationRequests = types.BoolValue(*clientResp.RequiresPushedAuthorizationRequests)
+	}
 	if clientResp.LaunchURL != "" {
 		plan.LaunchURL = types.StringValue(clientResp.LaunchURL)
 	} else {
@@ -636,15 +662,16 @@ func buildCreateRequestFromPlan(ctx context.Context, plan *clientResourceModel) 
 	}
 
 	return &client.OIDCClientCreateRequest{
-		Name:                     plan.Name.ValueString(),
-		CallbackURLs:             callbackURLs,
-		LogoutCallbackURLs:       logoutCallbackURLs,
-		IsPublic:                 plan.IsPublic.ValueBool(),
-		RequiresReauthentication: plan.RequiresReauthentication.ValueBool(),
-		LaunchURL:                launchPtr,
-		PkceEnabled:              plan.PkceEnabled.ValueBool(),
-		IsGroupRestricted:        isGroupRestricted,
-		Credentials:              buildCredentialsFromPlan(ctx, plan),
+		Name:                                plan.Name.ValueString(),
+		CallbackURLs:                        callbackURLs,
+		LogoutCallbackURLs:                  logoutCallbackURLs,
+		IsPublic:                            plan.IsPublic.ValueBool(),
+		RequiresReauthentication:            plan.RequiresReauthentication.ValueBool(),
+		RequiresPushedAuthorizationRequests: plan.RequiresPushedAuthorizationRequests.ValueBool(),
+		LaunchURL:                           launchPtr,
+		PkceEnabled:                         plan.PkceEnabled.ValueBool(),
+		IsGroupRestricted:                   isGroupRestricted,
+		Credentials:                         buildCredentialsFromPlan(ctx, plan),
 	}
 }
 

--- a/templates/resources/client.md.tmpl
+++ b/templates/resources/client.md.tmpl
@@ -99,10 +99,11 @@ resource "pocketid_client" "admin_portal" {
     "https://admin.example.com/logout"
   ]
 
-  is_public                 = false
-  pkce_enabled              = true
-  requires_reauthentication = true
-  launch_url                = "https://admin.example.com"
+  is_public                              = false
+  pkce_enabled                           = true
+  requires_reauthentication              = true
+  requires_pushed_authorization_requests = true
+  launch_url                             = "https://admin.example.com"
 
   # Only admins and developers can access this client
   allowed_user_groups = [


### PR DESCRIPTION
## Summary
Re-adds the `requires_pushed_authorization_requests` attribute to `pocketid_client` (PAR / RFC 9126), removed from #69 because the field is only in **unreleased** pocket-id (commit `68a5abdc`, after v2.8.0).

## Forward-compatible design
The original removal was due to "inconsistent result after apply": the v2.8.0 API omits the field, Go read it as `false`, clobbering a configured `true`.

This version fixes that:
- The client **read** model uses `*bool`, so an absent field (pocket-id ≤ v2.8.0) is distinguishable from `false`.
- Create/Read/Update **preserve** the configured value when the server omits the field; they only adopt the API value when present.
- On import (no prior state), it falls back to the default `false`.

Result: works today (value stored, not yet enforced server-side) and round-trips properly once pocket-id ships PAR.

## Validation
- Acceptance tests pass against live pocket-id v2.8.0: the PAR test (set true → preserved, flip to false), plus `_basic` (incl. import), federated identities, and update — no inconsistent-result errors, no perpetual diff.
- `go build`, `go vet -tags acc`, `golangci-lint` (0 issues), `gofmt`, unit tests all clean. Docs regenerated.

The attribute description documents that PAR is enforced only on pocket-id versions that support it.