### PR TITLE
ci: disable markdownlint MD060 (breaks Markdown Lint on all PRs)

### DIFF
--- a/.markdownlint.yaml
+++ b/.markdownlint.yaml
@@ -6,6 +6,7 @@ MD033: false  # Inline HTML
 MD041: false  # First line in file should be a top level header
 MD024: false  # Multiple headers with the same content
 MD036: false  # Emphasis used instead of a header
+MD060: false  # Table column style (pipe spacing) - too strict for conventional tables
 
 # Configure line length
 MD013:


### PR DESCRIPTION
markdownlint v0.40.0 (via the actions-group bump) added rule **MD060** (table column/pipe-spacing). It flags the conventional GitHub tables in committed markdown (e.g. `examples/complete/README.md`), so the **Markdown Lint** check fails on every PR.

Disables MD060 in `.markdownlint.yaml`, consistent with the other stylistic rules already turned off (MD033/041/024/036). `docs/**` and `.github/**` are already ignored by the cli2 config.