### PR TITLE
ci: test against pinned, latest, and dev pocket-id versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,8 @@ jobs:
           terraform_wrapper: false
 
       - name: Setup and start Pocket-ID test environment
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Install SQLite (needed for database operations)
           if [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -200,76 +202,6 @@ jobs:
           # Clean up test data
           rm -rf test-data
 
-  # Informational job: runs acceptance tests against the latest stable pocket-id
-  # release (resolved at runtime). continue-on-error so upstream drift never
-  # blocks PRs. Not part of ci-status needs.
-  acceptance-test-pocketid-latest:
-    name: Acceptance Test (pocket-id latest)
-    runs-on: ubuntu-latest
-    needs: [changes, test]
-    if: needs.changes.outputs.go == 'true'
-    continue-on-error: true
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
-
-      - name: Set up Go
-        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
-        with:
-          go-version: ${{ env.GO_VERSION }}
-          cache: true
-
-      - name: Setup Terraform
-        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
-        with:
-          terraform_version: "1.9.8"
-          terraform_wrapper: false
-
-      - name: Setup and start Pocket-ID test environment
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          # Install SQLite (needed for database operations)
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt-get update && sudo apt-get install -y sqlite3
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            brew install sqlite3 || true
-          fi
-
-          # Resolve the latest stable pocket-id release tag at runtime so we
-          # catch upstream drift without re-pinning the script default.
-          POCKET_ID_VERSION=$(gh api repos/pocket-id/pocket-id/releases/latest --jq .tag_name \
-            || curl -fsSL https://api.github.com/repos/pocket-id/pocket-id/releases/latest \
-              | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
-          echo "Resolved latest pocket-id version: $POCKET_ID_VERSION"
-          export POCKET_ID_VERSION
-
-          # Make script executable and run it
-          chmod +x ./scripts/prepare-test-db.sh
-          ./scripts/prepare-test-db.sh
-
-      - name: Run acceptance tests with coverage
-        env:
-          POCKETID_BASE_URL: http://localhost:1411
-          POCKETID_API_TOKEN: test-terraform-provider-token-123456789
-          TF_ACC: 1
-        run: |
-          # Point the test framework at the Terraform installed above so it does
-          # not try to download one (HashiCorp's release-signing GPG key expires
-          # and breaks the framework's auto-install).
-          export TF_ACC_TERRAFORM_PATH="$(which terraform)"
-          # -p 1 serializes packages so acceptance tests don't race against the
-          # single shared pocket-id instance (avoids cross-test state contamination).
-          go test -v -timeout 30m -p 1 -cover -coverprofile=acceptance-coverage.out ./internal/... -tags=acc
-
-      - name: Stop test environment
-        if: always()
-        run: |
-          # Kill pocket-id process
-          pkill -f pocket-id || true
-          # Clean up test data
-          rm -rf test-data
-
   # Informational job: runs acceptance tests against the pocket-id `:next` dev
   # container (main branch build). continue-on-error so upstream drift never
   # blocks PRs. Not part of ci-status needs.
@@ -298,6 +230,8 @@ jobs:
           terraform_wrapper: false
 
       - name: Setup and start Pocket-ID test environment
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Install SQLite (needed for database operations)
           if [[ "$RUNNER_OS" == "Linux" ]]; then
@@ -408,6 +342,8 @@ jobs:
           ls -la ~/.terraform.d/plugins/registry.terraform.io/trozz/pocketid/0.1.0/linux_amd64/
 
       - name: Setup and start Pocket-ID test environment
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           # Install SQLite (needed for database operations)
           if [[ "$RUNNER_OS" == "Linux" ]]; then

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,6 +200,141 @@ jobs:
           # Clean up test data
           rm -rf test-data
 
+  # Informational job: runs acceptance tests against the latest stable pocket-id
+  # release (resolved at runtime). continue-on-error so upstream drift never
+  # blocks PRs. Not part of ci-status needs.
+  acceptance-test-pocketid-latest:
+    name: Acceptance Test (pocket-id latest)
+    runs-on: ubuntu-latest
+    needs: [changes, test]
+    if: needs.changes.outputs.go == 'true'
+    continue-on-error: true
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.9.8"
+          terraform_wrapper: false
+
+      - name: Setup and start Pocket-ID test environment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # Install SQLite (needed for database operations)
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update && sudo apt-get install -y sqlite3
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install sqlite3 || true
+          fi
+
+          # Resolve the latest stable pocket-id release tag at runtime so we
+          # catch upstream drift without re-pinning the script default.
+          POCKET_ID_VERSION=$(gh api repos/pocket-id/pocket-id/releases/latest --jq .tag_name \
+            || curl -fsSL https://api.github.com/repos/pocket-id/pocket-id/releases/latest \
+              | grep -m1 '"tag_name"' | sed -E 's/.*"tag_name": *"([^"]+)".*/\1/')
+          echo "Resolved latest pocket-id version: $POCKET_ID_VERSION"
+          export POCKET_ID_VERSION
+
+          # Make script executable and run it
+          chmod +x ./scripts/prepare-test-db.sh
+          ./scripts/prepare-test-db.sh
+
+      - name: Run acceptance tests with coverage
+        env:
+          POCKETID_BASE_URL: http://localhost:1411
+          POCKETID_API_TOKEN: test-terraform-provider-token-123456789
+          TF_ACC: 1
+        run: |
+          # Point the test framework at the Terraform installed above so it does
+          # not try to download one (HashiCorp's release-signing GPG key expires
+          # and breaks the framework's auto-install).
+          export TF_ACC_TERRAFORM_PATH="$(which terraform)"
+          # -p 1 serializes packages so acceptance tests don't race against the
+          # single shared pocket-id instance (avoids cross-test state contamination).
+          go test -v -timeout 30m -p 1 -cover -coverprofile=acceptance-coverage.out ./internal/... -tags=acc
+
+      - name: Stop test environment
+        if: always()
+        run: |
+          # Kill pocket-id process
+          pkill -f pocket-id || true
+          # Clean up test data
+          rm -rf test-data
+
+  # Informational job: runs acceptance tests against the pocket-id `:next` dev
+  # container (main branch build). continue-on-error so upstream drift never
+  # blocks PRs. Not part of ci-status needs.
+  acceptance-test-pocketid-dev:
+    name: Acceptance Test (pocket-id dev)
+    runs-on: ubuntu-latest
+    needs: [changes, test]
+    if: needs.changes.outputs.go == 'true'
+    continue-on-error: true
+    env:
+      POCKET_ID_IMAGE: ghcr.io/pocket-id/pocket-id:next
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v4
+
+      - name: Set up Go
+        uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v5
+        with:
+          go-version: ${{ env.GO_VERSION }}
+          cache: true
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
+        with:
+          terraform_version: "1.9.8"
+          terraform_wrapper: false
+
+      - name: Setup and start Pocket-ID test environment
+        run: |
+          # Install SQLite (needed for database operations)
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update && sudo apt-get install -y sqlite3
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install sqlite3 || true
+          fi
+
+          # Make script executable and run it (container mode via POCKET_ID_IMAGE)
+          chmod +x ./scripts/prepare-test-db.sh
+          ./scripts/prepare-test-db.sh
+
+      - name: Run acceptance tests with coverage
+        env:
+          POCKETID_BASE_URL: http://localhost:1411
+          POCKETID_API_TOKEN: test-terraform-provider-token-123456789
+          TF_ACC: 1
+        run: |
+          # Point the test framework at the Terraform installed above so it does
+          # not try to download one (HashiCorp's release-signing GPG key expires
+          # and breaks the framework's auto-install).
+          export TF_ACC_TERRAFORM_PATH="$(which terraform)"
+          # -p 1 serializes packages so acceptance tests don't race against the
+          # single shared pocket-id instance (avoids cross-test state contamination).
+          go test -v -timeout 30m -p 1 -cover -coverprofile=acceptance-coverage.out ./internal/... -tags=acc
+
+      - name: Stop test environment
+        if: always()
+        run: |
+          # Stop and remove the pocket-id container
+          docker stop pocket-id-test || true
+          docker rm pocket-id-test || true
+          # Kill pocket-id process (no-op in container mode, kept for parity)
+          pkill -f pocket-id || true
+          # Clean up test data
+          rm -rf test-data
+
   build-provider:
     name: Build Provider
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,6 +37,10 @@ jobs:
               - 'go.mod'
               - 'go.sum'
               - '.golangci.yml'
+              # Re-run the integration suite when the test harness or this
+              # workflow changes, so harness/CI edits are actually validated.
+              - 'scripts/**'
+              - '.github/workflows/ci.yml'
             scripts:
               - 'scripts/**'
               - '.github/workflows/ci.yml'

--- a/scripts/prepare-test-db.sh
+++ b/scripts/prepare-test-db.sh
@@ -65,9 +65,23 @@ else
             darwin) OS="macos" ;;
         esac
 
-        # Pin to a known-good pocket-id version for reproducible tests.
-        # Override with POCKET_ID_VERSION to test against a different release.
-        POCKET_ID_VERSION="${POCKET_ID_VERSION:-v2.9.0}"
+        # Default to the latest stable pocket-id release so CI tests what most
+        # users run. Override with POCKET_ID_VERSION (e.g. for a reproducible
+        # local run); fall back to a known-good version if the release API is
+        # unavailable (e.g. rate limited).
+        if [ -z "$POCKET_ID_VERSION" ]; then
+            GH_AUTH=()
+            TOKEN="${GH_TOKEN:-${GITHUB_TOKEN:-}}"
+            [ -n "$TOKEN" ] && GH_AUTH=(-H "Authorization: Bearer $TOKEN")
+            POCKET_ID_VERSION=$(curl -fsSL "${GH_AUTH[@]}" \
+                https://api.github.com/repos/pocket-id/pocket-id/releases/latest 2>/dev/null \
+                | grep '"tag_name":' | head -1 | sed -E 's/.*"([^"]+)".*/\1/')
+            if [ -z "$POCKET_ID_VERSION" ]; then
+                echo "Could not resolve latest pocket-id release; falling back to v2.9.0"
+                POCKET_ID_VERSION="v2.9.0"
+            fi
+        fi
+        echo "Using pocket-id version: $POCKET_ID_VERSION"
 
         DOWNLOAD_URL="https://github.com/pocket-id/pocket-id/releases/download/${POCKET_ID_VERSION}/pocket-id-${OS}-${ARCH}"
         echo "Downloading from: $DOWNLOAD_URL"

--- a/scripts/prepare-test-db.sh
+++ b/scripts/prepare-test-db.sh
@@ -15,64 +15,89 @@ POCKET_ID_BINARY="$TEST_DATA_DIR/pocket-id"
 # Create test data directory
 mkdir -p "$TEST_DATA_DIR"
 
-# Download pocket-id binary if not present
-if [ ! -f "$POCKET_ID_BINARY" ]; then
-    echo "Downloading pocket-id binary..."
-    # Detect OS and architecture
-    OS=$(uname -s | tr '[:upper:]' '[:lower:]')
-    ARCH=$(uname -m)
+# pocket-id can run either from a downloaded binary (default) or from a
+# container image. Set POCKET_ID_IMAGE (e.g. ghcr.io/pocket-id/pocket-id:next)
+# to use container mode; otherwise the binary is downloaded and run directly.
+POCKET_ID_IMAGE="${POCKET_ID_IMAGE:-}"
 
-    # Map architecture names
-    case "$ARCH" in
-        x86_64) ARCH="amd64" ;;
-        aarch64|arm64) ARCH="arm64" ;;
-    esac
-
-    # Map OS names for pocket-id releases
-    case "$OS" in
-        darwin) OS="macos" ;;
-    esac
-
-    # Pin to a known-good pocket-id version for reproducible tests.
-    # Override with POCKET_ID_VERSION to test against a different release.
-    POCKET_ID_VERSION="${POCKET_ID_VERSION:-v2.8.0}"
-
-    DOWNLOAD_URL="https://github.com/pocket-id/pocket-id/releases/download/${POCKET_ID_VERSION}/pocket-id-${OS}-${ARCH}"
-    echo "Downloading from: $DOWNLOAD_URL"
-
-    curl -L -o "$POCKET_ID_BINARY" "$DOWNLOAD_URL"
-    chmod +x "$POCKET_ID_BINARY"
-fi
-
-# Create data directory for pocket-id
-mkdir -p "$TEST_DATA_DIR/data"
-
-# Start pocket-id in background
 # pocket-id v2 requires APP_URL and an ENCRYPTION_KEY of at least 16 bytes.
-echo "Starting pocket-id..."
 export APP_URL="${APP_URL:-http://localhost:1411}"
 export ENCRYPTION_KEY="${ENCRYPTION_KEY:-test-terraform-provider-encryption-key}"
 export TRUST_PROXY="${TRUST_PROXY:-false}"
 export MAXMIND_LICENSE_KEY="${MAXMIND_LICENSE_KEY:-}"
-cd "$TEST_DATA_DIR" && ./pocket-id > pocket-id.log 2>&1 &
-POCKET_ID_PID=$!
-cd "$PROJECT_ROOT"
 
-echo "Pocket-ID started with PID: $POCKET_ID_PID"
+# Create data directory for pocket-id (shared with the container volume mount)
+mkdir -p "$TEST_DATA_DIR/data"
 
-# Give pocket-id a moment to start
-sleep 2
+if [ -n "$POCKET_ID_IMAGE" ]; then
+    # Container mode: run pocket-id from a container image. The mounted
+    # $TEST_DATA_DIR/data is the same sqlite location the binary would use,
+    # so the wait-for-DB-and-seed logic below works identically.
+    echo "Starting pocket-id container from image: $POCKET_ID_IMAGE"
+    docker rm -f pocket-id-test >/dev/null 2>&1 || true
+    docker run -d --name pocket-id-test \
+        -e APP_URL \
+        -e ENCRYPTION_KEY \
+        -e TRUST_PROXY \
+        -e MAXMIND_LICENSE_KEY \
+        -e PUID="$(id -u)" \
+        -e PGID="$(id -g)" \
+        -p 1411:1411 \
+        -v "$TEST_DATA_DIR/data:/app/data" \
+        "$POCKET_ID_IMAGE"
+    echo "Pocket-ID container started."
+else
+    # Binary mode: download pocket-id binary if not present.
+    if [ ! -f "$POCKET_ID_BINARY" ]; then
+        echo "Downloading pocket-id binary..."
+        # Detect OS and architecture
+        OS=$(uname -s | tr '[:upper:]' '[:lower:]')
+        ARCH=$(uname -m)
 
-# Check if the process is still running
-if ! kill -0 $POCKET_ID_PID 2>/dev/null; then
-    echo "ERROR: Pocket-ID process died immediately!"
-    echo "Checking log file..."
-    if [ -f "$TEST_DATA_DIR/pocket-id.log" ]; then
-        cat "$TEST_DATA_DIR/pocket-id.log"
-    else
-        echo "No log file found!"
+        # Map architecture names
+        case "$ARCH" in
+            x86_64) ARCH="amd64" ;;
+            aarch64|arm64) ARCH="arm64" ;;
+        esac
+
+        # Map OS names for pocket-id releases
+        case "$OS" in
+            darwin) OS="macos" ;;
+        esac
+
+        # Pin to a known-good pocket-id version for reproducible tests.
+        # Override with POCKET_ID_VERSION to test against a different release.
+        POCKET_ID_VERSION="${POCKET_ID_VERSION:-v2.9.0}"
+
+        DOWNLOAD_URL="https://github.com/pocket-id/pocket-id/releases/download/${POCKET_ID_VERSION}/pocket-id-${OS}-${ARCH}"
+        echo "Downloading from: $DOWNLOAD_URL"
+
+        curl -L -o "$POCKET_ID_BINARY" "$DOWNLOAD_URL"
+        chmod +x "$POCKET_ID_BINARY"
     fi
-    exit 1
+
+    # Start pocket-id in background
+    echo "Starting pocket-id..."
+    cd "$TEST_DATA_DIR" && ./pocket-id > pocket-id.log 2>&1 &
+    POCKET_ID_PID=$!
+    cd "$PROJECT_ROOT"
+
+    echo "Pocket-ID started with PID: $POCKET_ID_PID"
+
+    # Give pocket-id a moment to start
+    sleep 2
+
+    # Check if the process is still running
+    if ! kill -0 $POCKET_ID_PID 2>/dev/null; then
+        echo "ERROR: Pocket-ID process died immediately!"
+        echo "Checking log file..."
+        if [ -f "$TEST_DATA_DIR/pocket-id.log" ]; then
+            cat "$TEST_DATA_DIR/pocket-id.log"
+        else
+            echo "No log file found!"
+        fi
+        exit 1
+    fi
 fi
 
 # Wait for database to exist and migrations to complete
@@ -97,8 +122,13 @@ if [ $RETRY_COUNT -eq $MAX_RETRIES ]; then
     ls -la "$TEST_DATA_DIR/data/" || true
     if [ ! -f "$DB_PATH" ]; then
         echo "Database file does not exist!"
-        echo "Checking pocket-id log..."
-        cat "$TEST_DATA_DIR/pocket-id.log" || true
+        if [ -n "$POCKET_ID_IMAGE" ]; then
+            echo "Checking pocket-id container logs..."
+            docker logs pocket-id-test || true
+        else
+            echo "Checking pocket-id log..."
+            cat "$TEST_DATA_DIR/pocket-id.log" || true
+        fi
     else
         echo "Tables in database:"
         sqlite3 "$DB_PATH" "SELECT name FROM sqlite_master WHERE type='table';" || true
@@ -172,4 +202,8 @@ for i in {1..10}; do
 done
 
 echo "Pocket-ID test environment ready!"
-echo "PID: $POCKET_ID_PID"
+if [ -n "$POCKET_ID_IMAGE" ]; then
+    echo "Container: pocket-id-test"
+else
+    echo "PID: $POCKET_ID_PID"
+fi


### PR DESCRIPTION
Adds pocket-id version coverage to CI. **The provider is v2-only, so v1 is not a valid test target** and is intentionally excluded.

## Design
- **Gate = latest stable pocket-id** (what most users run). `scripts/prepare-test-db.sh` now resolves the latest release tag at runtime (GH_TOKEN-authenticated, with a `v2.9.0` fallback if the release API is unavailable). The existing blocking acceptance + Terraform-compat jobs inherit this, so they gate on latest. `POCKET_ID_VERSION` still overrides (e.g. for reproducible local runs).
- **Non-blocking `:next` dev job** (`continue-on-error`, not in the ci-status gate): runs against `ghcr.io/pocket-id/pocket-id:next` (main-branch container) to catch **unreleased** upstream changes early (the kind of drift that the PAR field would have flagged). Never blocks PRs.

## Harness
- New `POCKET_ID_IMAGE` env enables container mode (used by the dev job); binary mode (download) is unchanged otherwise. The wait-for-DB + sqlite seeding is shared between both modes.

## Verified
- `bash -n` + `shellcheck` clean; workflow YAML parses.
- Binary mode confirmed locally end-to-end against the resolved latest (DB seeded, API returns 200).
- The `:next` container job is CI-validated only.

Note: gating on latest means a future pocket-id release with a breaking change will turn the gate red on all PRs until the provider is updated — the accepted tradeoff for testing what users actually run; the `:next` job gives advance warning.