### PR TITLE
fix(client): handle PAR public-client coercion (test + plan-time validator)

### DIFF
--- a/docs/resources/client.md
+++ b/docs/resources/client.md
@@ -174,7 +174,7 @@ output "spa_client_id" {
 - `launch_url` (String) Optional launch URL associated with the client.
 - `logout_callback_urls` (List of String) List of allowed logout callback URLs for the OIDC client.
 - `pkce_enabled` (Boolean) Whether PKCE is enabled for this client. Defaults to true.
-- `requires_pushed_authorization_requests` (Boolean) Whether this client requires Pushed Authorization Requests (PAR, RFC 9126). Defaults to false. Note: this is enforced only by Pocket-ID versions that support PAR (added after v2.8.0); on older servers the value is stored in state but not enforced.
+- `requires_pushed_authorization_requests` (Boolean) Whether this client requires Pushed Authorization Requests (PAR, RFC 9126). Defaults to false. Applies to confidential clients only — Pocket-ID coerces this to false for public clients (is_public = true). Enforced only by Pocket-ID versions that support PAR (v2.9.0+); on older versions the value is stored in state but not enforced.
 - `requires_reauthentication` (Boolean) Whether this client requires reauthentication for certain flows. Defaults to false.
 
 ### Read-Only

--- a/internal/provider/resource_client_test.go
+++ b/internal/provider/resource_client_test.go
@@ -428,3 +428,25 @@ resource "pocketid_client" "test" {
 }
 `, name, par)
 }
+
+func TestAccResourceClient_parPublicConflict(t *testing.T) {
+	resource.Test(t, resource.TestCase{
+		PreCheck:                 func() { testAccPreCheck(t) },
+		ProtoV6ProviderFactories: testAccProtoV6ProviderFactories,
+		Steps: []resource.TestStep{
+			{
+				// PAR on a public client is rejected at plan time.
+				Config: testAccProviderConfig() + `
+resource "pocketid_client" "test" {
+  name          = "par-public-conflict"
+  callback_urls = ["https://example.com/callback"]
+  is_public     = true
+
+  requires_pushed_authorization_requests = true
+}
+`,
+				ExpectError: regexp.MustCompile("Invalid PAR configuration"),
+			},
+		},
+	})
+}

--- a/internal/provider/resource_client_test.go
+++ b/internal/provider/resource_client_test.go
@@ -416,11 +416,13 @@ func TestAccResourceClient_requiresPushedAuthorizationRequests(t *testing.T) {
 }
 
 func testAccResourceClientConfig_par(name string, par bool) string {
+	// PAR applies to confidential clients; Pocket-ID coerces it to false for
+	// public clients, so this must use a non-public client.
 	return testAccProviderConfig() + fmt.Sprintf(`
 resource "pocketid_client" "test" {
   name          = %[1]q
   callback_urls = ["https://example.com/callback"]
-  is_public     = true
+  is_public     = false
 
   requires_pushed_authorization_requests = %[2]t
 }

--- a/internal/resources/client_resource.go
+++ b/internal/resources/client_resource.go
@@ -137,7 +137,8 @@ func (r *clientResource) Schema(_ context.Context, _ resource.SchemaRequest, res
 			},
 			"requires_pushed_authorization_requests": schema.BoolAttribute{
 				Description: "Whether this client requires Pushed Authorization Requests (PAR, RFC 9126). Defaults to false. " +
-					"Note: this is enforced only by Pocket-ID versions that support PAR (added after v2.8.0); on older servers the value is stored in state but not enforced.",
+					"Applies to confidential clients only — Pocket-ID coerces this to false for public clients (is_public = true). " +
+					"Enforced only by Pocket-ID versions that support PAR (v2.9.0+); on older versions the value is stored in state but not enforced.",
 				Optional: true,
 				Computed: true,
 				Default:  booldefault.StaticBool(false),

--- a/internal/resources/client_resource.go
+++ b/internal/resources/client_resource.go
@@ -24,9 +24,10 @@ import (
 
 // Ensure the implementation satisfies the expected interfaces.
 var (
-	_ resource.Resource                = &clientResource{}
-	_ resource.ResourceWithConfigure   = &clientResource{}
-	_ resource.ResourceWithImportState = &clientResource{}
+	_ resource.Resource                   = &clientResource{}
+	_ resource.ResourceWithConfigure      = &clientResource{}
+	_ resource.ResourceWithImportState    = &clientResource{}
+	_ resource.ResourceWithValidateConfig = &clientResource{}
 )
 
 // NewClientResource is a helper function to simplify the provider implementation.
@@ -215,6 +216,27 @@ func (r *clientResource) Configure(_ context.Context, req resource.ConfigureRequ
 	}
 
 	r.client = client
+}
+
+// ValidateConfig rejects configurations the API would silently coerce, giving a
+// clear plan-time error instead of an inconsistent-result error after apply.
+func (r *clientResource) ValidateConfig(ctx context.Context, req resource.ValidateConfigRequest, resp *resource.ValidateConfigResponse) {
+	var config clientResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &config)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Pocket-ID coerces requires_pushed_authorization_requests to false for
+	// public clients, so true + is_public is never satisfiable.
+	if config.IsPublic.ValueBool() && config.RequiresPushedAuthorizationRequests.ValueBool() {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("requires_pushed_authorization_requests"),
+			"Invalid PAR configuration",
+			"requires_pushed_authorization_requests can only be true for confidential clients. "+
+				"Set is_public = false to use Pushed Authorization Requests.",
+		)
+	}
 }
 
 // Create creates the resource and sets the initial Terraform state.


### PR DESCRIPTION
The new **gate-on-latest** job (#76) caught a real upstream change on its first run: pocket-id **v2.9.0** shipped the `requires_pushed_authorization_requests` (PAR) field and **coerces it to `false` for public clients**.

## Cause
- PAR was unreleased when added (#72); v2.9.0 released it.
- Verified against live v2.9.0: PAR is honored only for **confidential** clients (`is_public = false`); for public clients the server forces it to `false`.
- The PAR acceptance test used `is_public = true`, so the server returned `false` while config said `true` → "Provider produced inconsistent result after apply".

## Changes
1. **Test fix** — PAR acceptance test now uses a confidential client (verified passing against live v2.9.0).
2. **Plan-time validator** — `ValidateConfig` now rejects `requires_pushed_authorization_requests = true` on a public client with a clear error ("Invalid PAR configuration"), instead of letting it fail post-apply. Covered by `TestAccResourceClient_parPublicConflict`.
3. **Docs** — attribute description notes the confidential-only behavior and that PAR is enforced on v2.9.0+; docs regenerated.

## Why it matters
Without this, **main's acceptance gate is red** (since #76 merged the gate-on-latest with the old public-client test). This restores it. It's also a clean proof that the testing expansion works — the latest-gate + `:next` dev job both went green here, and the gate flagged genuine upstream drift.

## Validation
`go build`, `go vet -tags acc`, `golangci-lint` (0 issues), `gofmt`, unit tests all pass. Client acceptance suite (incl. PAR round-trip + the validator) passes against live pocket-id v2.9.0.