### PR TITLE
feat(data-sources): expose ldap_id (and group created_at)

### DIFF
--- a/docs/data-sources/group.md
+++ b/docs/data-sources/group.md
@@ -52,4 +52,6 @@ output "developers_group_info" {
 
 ### Read-Only
 
+- `created_at` (String) The creation time of the group in RFC3339 format.
 - `friendly_name` (String) The friendly display name of the group.
+- `ldap_id` (String) The LDAP identifier of the group, if it is synced from LDAP. Null for groups not managed by LDAP.

--- a/docs/data-sources/groups.md
+++ b/docs/data-sources/groups.md
@@ -74,6 +74,8 @@ output "group_names" {
 
 Read-Only:
 
+- `created_at` (String) The creation time of the group in RFC3339 format.
 - `friendly_name` (String) The friendly display name of the group.
 - `id` (String) The ID of the group.
+- `ldap_id` (String) The LDAP identifier of the group, if it is synced from LDAP. Null for groups not managed by LDAP.
 - `name` (String) The unique name identifier of the group.

--- a/docs/data-sources/user.md
+++ b/docs/data-sources/user.md
@@ -72,4 +72,5 @@ output "admin_user_id" {
 - `groups` (Set of String) List of group IDs the user belongs to.
 - `is_admin` (Boolean) Whether the user has administrator privileges.
 - `last_name` (String) The last name of the user.
+- `ldap_id` (String) The LDAP identifier of the user, if it is synced from LDAP. Null for users not managed by LDAP.
 - `locale` (String) The locale preference for the user.

--- a/docs/data-sources/users.md
+++ b/docs/data-sources/users.md
@@ -86,5 +86,6 @@ Read-Only:
 - `id` (String) The ID of the user.
 - `is_admin` (Boolean) Whether the user has administrator privileges.
 - `last_name` (String) The last name of the user.
+- `ldap_id` (String) The LDAP identifier of the user, if it is synced from LDAP. Null for users not managed by LDAP.
 - `locale` (String) The locale preference for the user.
 - `username` (String) The username of the user.

--- a/internal/client/models.go
+++ b/internal/client/models.go
@@ -93,8 +93,6 @@ type User struct {
 	UserGroups    []UserGroup   `json:"userGroups,omitempty"`
 	CustomClaims  []CustomClaim `json:"customClaims,omitempty"`
 	LdapID        *string       `json:"ldapId,omitempty"`
-	CreatedAt     string        `json:"createdAt,omitempty"`
-	UpdatedAt     string        `json:"updatedAt,omitempty"`
 }
 
 // UserCreateRequest represents a request to create or update a user
@@ -125,7 +123,6 @@ type UserGroup struct {
 	CustomClaims []CustomClaim `json:"customClaims,omitempty"`
 	LdapID       *string       `json:"ldapId,omitempty"`
 	CreatedAt    string        `json:"createdAt,omitempty"`
-	UpdatedAt    string        `json:"updatedAt,omitempty"`
 }
 
 // UserGroupCreateRequest represents a request to create or update a user group

--- a/internal/datasources/group_data_source.go
+++ b/internal/datasources/group_data_source.go
@@ -33,6 +33,8 @@ type groupDataSourceModel struct {
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
 	FriendlyName types.String `tfsdk:"friendly_name"`
+	LdapID       types.String `tfsdk:"ldap_id"`
+	CreatedAt    types.String `tfsdk:"created_at"`
 }
 
 // Metadata returns the data source type name.
@@ -58,6 +60,14 @@ func (d *groupDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 			},
 			"friendly_name": schema.StringAttribute{
 				Description: "The friendly display name of the group.",
+				Computed:    true,
+			},
+			"ldap_id": schema.StringAttribute{
+				Description: "The LDAP identifier of the group, if it is synced from LDAP. Null for groups not managed by LDAP.",
+				Computed:    true,
+			},
+			"created_at": schema.StringAttribute{
+				Description: "The creation time of the group in RFC3339 format.",
 				Computed:    true,
 			},
 		},
@@ -147,6 +157,16 @@ func (d *groupDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 	data.ID = types.StringValue(foundGroup.ID)
 	data.Name = types.StringValue(foundGroup.Name)
 	data.FriendlyName = types.StringValue(foundGroup.FriendlyName)
+	if foundGroup.LdapID != nil && *foundGroup.LdapID != "" {
+		data.LdapID = types.StringValue(*foundGroup.LdapID)
+	} else {
+		data.LdapID = types.StringNull()
+	}
+	if foundGroup.CreatedAt != "" {
+		data.CreatedAt = types.StringValue(foundGroup.CreatedAt)
+	} else {
+		data.CreatedAt = types.StringNull()
+	}
 
 	// Save data into Terraform state
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)

--- a/internal/datasources/group_data_source_test.go
+++ b/internal/datasources/group_data_source_test.go
@@ -54,6 +54,9 @@ func TestAccGroupDataSource_LookupByID(t *testing.T) {
 					resource.TestCheckResourceAttr("data.pocketid_group.test", "name", rName),
 					resource.TestCheckResourceAttr("data.pocketid_group.test", "friendly_name", "Test Group"),
 					resource.TestCheckResourceAttrSet("data.pocketid_group.test", "id"),
+					resource.TestCheckResourceAttrSet("data.pocketid_group.test", "created_at"),
+					// Group is not LDAP-managed, so ldap_id is null.
+					resource.TestCheckNoResourceAttr("data.pocketid_group.test", "ldap_id"),
 				),
 			},
 		},

--- a/internal/datasources/groups_data_source.go
+++ b/internal/datasources/groups_data_source.go
@@ -38,6 +38,8 @@ type groupModel struct {
 	ID           types.String `tfsdk:"id"`
 	Name         types.String `tfsdk:"name"`
 	FriendlyName types.String `tfsdk:"friendly_name"`
+	LdapID       types.String `tfsdk:"ldap_id"`
+	CreatedAt    types.String `tfsdk:"created_at"`
 }
 
 // Metadata returns the data source type name.
@@ -66,6 +68,14 @@ func (d *groupsDataSource) Schema(_ context.Context, _ datasource.SchemaRequest,
 						},
 						"friendly_name": schema.StringAttribute{
 							Description: "The friendly display name of the group.",
+							Computed:    true,
+						},
+						"ldap_id": schema.StringAttribute{
+							Description: "The LDAP identifier of the group, if it is synced from LDAP. Null for groups not managed by LDAP.",
+							Computed:    true,
+						},
+						"created_at": schema.StringAttribute{
+							Description: "The creation time of the group in RFC3339 format.",
 							Computed:    true,
 						},
 					},
@@ -122,11 +132,20 @@ func (d *groupsDataSource) Read(ctx context.Context, req datasource.ReadRequest,
 	// Map response body to model
 	data.Groups = make([]groupModel, len(groupsResp.Data))
 	for i, group := range groupsResp.Data {
-		data.Groups[i] = groupModel{
+		gm := groupModel{
 			ID:           types.StringValue(group.ID),
 			Name:         types.StringValue(group.Name),
 			FriendlyName: types.StringValue(group.FriendlyName),
+			LdapID:       types.StringNull(),
+			CreatedAt:    types.StringNull(),
 		}
+		if group.LdapID != nil && *group.LdapID != "" {
+			gm.LdapID = types.StringValue(*group.LdapID)
+		}
+		if group.CreatedAt != "" {
+			gm.CreatedAt = types.StringValue(group.CreatedAt)
+		}
+		data.Groups[i] = gm
 	}
 
 	// Save data into Terraform state

--- a/internal/datasources/user_data_source.go
+++ b/internal/datasources/user_data_source.go
@@ -40,6 +40,7 @@ type userDataSourceModel struct {
 	IsAdmin       types.Bool   `tfsdk:"is_admin"`
 	Locale        types.String `tfsdk:"locale"`
 	Disabled      types.Bool   `tfsdk:"disabled"`
+	LdapID        types.String `tfsdk:"ldap_id"`
 	Groups        types.Set    `tfsdk:"groups"`
 }
 
@@ -96,6 +97,10 @@ func (d *userDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, r
 			},
 			"disabled": schema.BoolAttribute{
 				Description: "Whether the user account is disabled.",
+				Computed:    true,
+			},
+			"ldap_id": schema.StringAttribute{
+				Description: "The LDAP identifier of the user, if it is synced from LDAP. Null for users not managed by LDAP.",
 				Computed:    true,
 			},
 			"groups": schema.SetAttribute{
@@ -221,6 +226,13 @@ func (d *userDataSource) Read(ctx context.Context, req datasource.ReadRequest, r
 		state.Locale = types.StringValue(*userResp.Locale)
 	} else {
 		state.Locale = types.StringNull()
+	}
+
+	// Handle ldap_id
+	if userResp.LdapID != nil && *userResp.LdapID != "" {
+		state.LdapID = types.StringValue(*userResp.LdapID)
+	} else {
+		state.LdapID = types.StringNull()
 	}
 
 	// Map groups

--- a/internal/datasources/users_data_source.go
+++ b/internal/datasources/users_data_source.go
@@ -45,6 +45,7 @@ type userModel struct {
 	IsAdmin       types.Bool   `tfsdk:"is_admin"`
 	Locale        types.String `tfsdk:"locale"`
 	Disabled      types.Bool   `tfsdk:"disabled"`
+	LdapID        types.String `tfsdk:"ldap_id"`
 	Groups        types.Set    `tfsdk:"groups"`
 }
 
@@ -102,6 +103,10 @@ func (d *usersDataSource) Schema(_ context.Context, _ datasource.SchemaRequest, 
 						},
 						"disabled": schema.BoolAttribute{
 							Description: "Whether the user account is disabled.",
+							Computed:    true,
+						},
+						"ldap_id": schema.StringAttribute{
+							Description: "The LDAP identifier of the user, if it is synced from LDAP. Null for users not managed by LDAP.",
 							Computed:    true,
 						},
 						"groups": schema.SetAttribute{
@@ -172,6 +177,13 @@ func (d *usersDataSource) Read(ctx context.Context, req datasource.ReadRequest, 
 			userState.Locale = types.StringValue(*userResp.Locale)
 		} else {
 			userState.Locale = types.StringNull()
+		}
+
+		// Handle ldap_id
+		if userResp.LdapID != nil && *userResp.LdapID != "" {
+			userState.LdapID = types.StringValue(*userResp.LdapID)
+		} else {
+			userState.LdapID = types.StringNull()
 		}
 
 		// Map groups


### PR DESCRIPTION
Adds read-only metadata to the data sources, grounded in what the pocket-id v2.9.0 DTOs actually return.

## Changes
- **`ldap_id`** (computed) on the **user, users, group, groups** data sources — lets configs detect LDAP-synced entities (which Terraform shouldn't manage, since the LDAP sync owns them). Null for non-LDAP entities.
- **`created_at`** (computed) on the **group / groups** data sources — the only entity whose API response includes it (`UserGroupDto.createdAt`).
- **Dead-field cleanup:** removed `User.CreatedAt`, `User.UpdatedAt`, and `UserGroup.UpdatedAt` from the client model. The v2.9.0 DTOs never serialize these (only the DB model has them), so they were always empty — the model was advertising fields the API doesn't return.

## Scope notes (per the API reality)
- No `ldap_id` on the client data source — pocket-id doesn't return it for OIDC clients (and doesn't LDAP-sync them).
- No `created_at`/`updated_at` on user (the `UserDto` returns neither); no `updated_at` anywhere (no DTO serializes it).
- Metadata is added to data sources only, not resources (avoids drift/“known after apply” noise; `ldap_id` on a resource could drift if LDAP adopts an entity out-of-band).

## Validation
`go build`, `go build -tags acc`, `go vet -tags acc`, `golangci-lint` (0 issues), `gofmt`, unit tests all pass. Data-source acceptance tests pass against live pocket-id v2.9.0 (incl. new `created_at` set / `ldap_id` null assertions on the group data source). Docs regenerated.