### PR TITLE
ci(goreleaser): ignore dev tags when resolving previous tag

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,6 +6,16 @@ version: 2
 
 # This is an example .goreleaser.yml file with some sensible defaults.
 # Make sure to check the documentation at https://goreleaser.com
+
+# Git configuration
+git:
+  # Ignore dev pre-release tags when resolving the previous/current tag.
+  # The cleanup-on-tag-push workflow deletes these tags during a release, so
+  # using one as the changelog base produces a 404 against the GitHub compare
+  # API. Ignoring them makes the previous tag resolve to the last stable release.
+  ignore_tags:
+    - "*-dev*"
+
 before:
   hooks:
     # You may remove this if you don't use go modules.


### PR DESCRIPTION
## Problem
The `v2.3.0` release failed at changelog generation:

```
GET .../compare/v2.2.1-dev.20260617084535+b1f8e39...v2.3.0: 404 Not Found
```

GoReleaser resolved the most recent **dev** tag as the previous release and queried the GitHub compare API for it. But the `Cleanup Pre-releases` workflow (#78, runs on the same tag push) had just deleted that dev tag from origin, so the API returns 404. A release-time race that recurs on every release, since each release deletes its own cycle's dev tags.

## Fix
Add `git.ignore_tags: ["*-dev*"]` so GoReleaser ignores dev pre-release tags when resolving the previous/current tag. The previous tag now resolves to the last **stable** release (e.g. `v2.2.0`), which always exists, fixing both the changelog compare API call and the `Full Changelog` footer link.

Validated with `goreleaser check` against GoReleaser 2.16.0 (the CI version).